### PR TITLE
Feature/refactor param store dag

### DIFF
--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -12,13 +12,21 @@ class AWSParamStoreToAirflowDAG:
     """
 
     """
-    def __init__(self, ssm_prefix: str, s3_region: str, **kwargs):
+    def __init__(self,
+        ssm_prefix: str,
+        region_name: str = None,
+        **kwargs
+    ):
         self.ssm_prefix = ssm_prefix
-        self.s3_region = s3_region
+        self.region_name = region_name
         self.dag = self.build_dag(**kwargs)
 
 
-    def build_dag(self, dag_id: str, default_args: dict, **kwargs):
+    def build_dag(self,
+        dag_id: str,
+        default_args: dict,
+        **kwargs
+    ):
         """
 
         :param dag_id:
@@ -31,10 +39,11 @@ class AWSParamStoreToAirflowDAG:
             """
             :return:
             """
-            param_store = SSMParameterStore(prefix=self.ssm_prefix, region_name=self.s3_region)
+            param_store = SSMParameterStore(prefix=self.ssm_prefix, region_name=self.region_name)
 
-            for param_secret in param_store.values():
-                self.create_conn(**param_secret)
+            for param_name, param_secret in param_store.items():
+                conn_id = param_name.replace(self.ssm_prefix, "")
+                self.create_conn(conn_id=conn_id, **param_secret)
 
 
         # This syntax ensures param_store stays hidden within the class.
@@ -52,15 +61,15 @@ class AWSParamStoreToAirflowDAG:
     # stackoverflow link:
     # https://stackoverflow.com/questions/51863881/is-there-a-way-to-create-modify-connections-through-airflow-api
     @staticmethod
-    def create_conn(**kwargs) -> Connection:
+    def create_conn(conn_id: str, **kwargs) -> Connection:
         """
         Store a new connection in Airflow Meta DB
 
+        :param conn_id:
         :param kwargs:
         :return:
 
         :Keyword Arguments:
-            * conn_id
             * conn_type
             * host
             * schema
@@ -69,28 +78,23 @@ class AWSParamStoreToAirflowDAG:
             * port
             * extra
         """
-        conn = Connection(**kwargs)
-
+        conn = Connection(conn_id=conn_id, **kwargs)
         session = airflow.settings.Session()
-        conn_name = (
-            session
-                .query(Connection)
-                .filter(Connection.conn_id == conn.conn_id)
-                .first()
-        )
 
-        if str(conn_name) == str(conn.conn_id):
+        # Verify whether the connection already exists in Airflow.
+        if session.query(Connection).filter(Connection.conn_id == conn.conn_id).first():
             logging.warning(
                 f"Connection {conn.conn_id} already exists!"
             )
             return None
 
-        session.add(conn)
-        session.commit()
+        else:
+            session.add(conn)
+            session.commit()
 
-        logging.info(Connection.log_info(conn))
-        logging.info(
-            f"Connection {conn_id} was added."
-        )
+            logging.info(Connection.log_info(conn))
+            logging.info(
+                f"Connection {conn_id} was added."
+            )
 
-        return conn
+            return conn

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -41,8 +41,10 @@ class AWSParamStoreToAirflowDAG:
             """
             param_store = SSMParameterStore(prefix=self.ssm_prefix, region_name=self.region_name)
 
-            for param_name, param_secret in param_store.items():
+            for param_name in param_store.keys():
                 conn_id = param_name.replace(self.ssm_prefix, "")
+                param_secret = param_store[param_name]
+                print(conn_id)
                 self.create_conn(conn_id=conn_id, **param_secret)
 
 

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -14,7 +14,7 @@ class AWSParamStoreToAirflowDAG:
     """
     def __init__(self,
         ssm_prefix: str,
-        region_name: str = None,
+        region_name: str,
         **kwargs
     ):
         self.ssm_prefix = ssm_prefix

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import airflow
@@ -43,8 +44,7 @@ class AWSParamStoreToAirflowDAG:
 
             for param_name in param_store.keys():
                 conn_id = param_name.replace(self.ssm_prefix, "")
-                param_secret = param_store[param_name]
-                print(conn_id)
+                param_secret = json.loads(param_store[param_name])
                 self.create_conn(conn_id=conn_id, **param_secret)
 
 

--- a/ea_airflow_util/dags/dag_util/ssm_parameter_store.py
+++ b/ea_airflow_util/dags/dag_util/ssm_parameter_store.py
@@ -38,6 +38,10 @@ class SSMParameterStore:
         region_name: Optional[str]  = None,
         ttl        : Optional[bool] = None
     ) -> None:
+        # Infer region from EC2 machine if none provided.
+        if region_name is None:
+            region_name = boto3.Session().region_name
+
         self._prefix = (prefix or '').rstrip('/') + '/'
         self._client = ssm_client or boto3.client('ssm', region_name=region_name)
         self._keys = None

--- a/ea_airflow_util/dags/dag_util/ssm_parameter_store.py
+++ b/ea_airflow_util/dags/dag_util/ssm_parameter_store.py
@@ -33,10 +33,10 @@ class SSMParameterStore:
     """
 
     def __init__(self,
-            prefix     : Optional[str]  = None,
-            ssm_client : Optional[str]  = None,
-            region_name: Optional[str]  = None,
-            ttl        : Optional[bool] = None
+        prefix     : Optional[str]  = None,
+        ssm_client : Optional[str]  = None,
+        region_name: Optional[str]  = None,
+        ttl        : Optional[bool] = None
     ) -> None:
         self._prefix = (prefix or '').rstrip('/') + '/'
         self._client = ssm_client or boto3.client('ssm', region_name=region_name)

--- a/ea_airflow_util/dags/dag_util/ssm_parameter_store.py
+++ b/ea_airflow_util/dags/dag_util/ssm_parameter_store.py
@@ -38,10 +38,6 @@ class SSMParameterStore:
         region_name: Optional[str]  = None,
         ttl        : Optional[bool] = None
     ) -> None:
-        # Infer region from EC2 machine if none provided.
-        if region_name is None:
-            region_name = boto3.Session().region_name
-
         self._prefix = (prefix or '').rstrip('/') + '/'
         self._client = ssm_client or boto3.client('ssm', region_name=region_name)
         self._keys = None


### PR DESCRIPTION
This finalizes the code for running the AWSParamStoreToAirflowDAG in EDU implementations. By declaring Airflow connections using a consistent SSM prefix, these can be saved as secure JSON strings and updated in SystemsManager and imported automatically into Airflow as connections.

To update an existing connection, the connection should be deleted on Airflow. We can have a future discussion about whether the DAG should update connections in place as a default behavior.