### PR TITLE
Feature/refactor paramstore dag

### DIFF
--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -156,7 +156,13 @@ class AWSParamStoreToAirflowDAG:
             # Add each param-combination to the connection kwargs dictionary.
             for param_name in param_store.keys():
                 logging.info(param_name)
-                tenant_code, param_type = param_name.replace(ssm_prefix, "").strip('/').split('/')
+                try:
+                    tenant_code, param_type = param_name.replace(ssm_prefix, "").strip('/').split('/')
+                except:
+                    logging.warning(
+                        f"Parameter {param_name} does not match expected shape and will be skipped."
+                    )
+                    continue
 
                 # Translate the tenant-code if provided in the mapping.
                 if tenant_code in self.tenant_mapping:

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -111,15 +111,7 @@ class AWSParamStoreToAirflowDAG:
 
         @task
         def upload_param_connections():
-            """
-            Attempt to upload connections to Airflow, warning if already present or incomplete.
-            https://stackoverflow.com/questions/51863881
-            """
-            if not self.connection_kwargs:
-                raise AirflowSkipException(
-                    "No connections were found using specified arguments!"
-                )
-
+            """ Wrapper around helper class-method to upload connections """
             self.upload_connection_kwargs_to_airflow()
 
 
@@ -174,6 +166,14 @@ class AWSParamStoreToAirflowDAG:
         Attempt to upload connections to Airflow, warning if already present or incomplete.
         https://stackoverflow.com/questions/51863881
         """
+        # Verify the connection-kwargs declaration succeeded.
+        # Note: this must go within the helper, as Airflow uses the empty dict at parse-time.
+        if not self.connection_kwargs:
+            raise AirflowSkipException(
+                "No connections were found using specified arguments!"
+            )
+
+        # Establish a connection and begin upload.
         session = airflow.settings.Session()
 
         for conn_id, conn_kwargs in self.connection_kwargs.items():

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -106,8 +106,6 @@ class AWSParamStoreToAirflowDAG:
             if self.prefix_year_mapping:
                 self.build_kwargs_from_prefix_year_mapping()
 
-            logging.info(self.connection_kwargs)
-
 
         @task
         def upload_param_connections():
@@ -168,6 +166,7 @@ class AWSParamStoreToAirflowDAG:
         """
         # Verify the connection-kwargs declaration succeeded.
         # Note: this must go within the helper, as Airflow uses the empty dict at parse-time.
+        logging.info(self.connection_kwargs)
         if not self.connection_kwargs:
             raise AirflowSkipException(
                 "No connections were found using specified arguments!"

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -39,7 +39,7 @@ class ConnectionKwargs:
                 f"Connection is missing one or more required fields."
             )
 
-        return Connection(conn_id=conn_id, **self.__kwargs)
+        return Connection(conn_id=conn_id, conn_type='http', **self.__kwargs)
 
 
 class AWSParamStoreToAirflowDAG:

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -67,9 +67,10 @@ class AWSParamStoreToAirflowDAG:
         **kwargs
     ):
         self.region_name = region_name
-        self.prefix_year_mapping = prefix_year_mapping
-        self.tenant_mapping = tenant_mapping or {}
         self.overwrite = overwrite
+
+        self.prefix_year_mapping = prefix_year_mapping
+        self.tenant_mapping      = tenant_mapping or {}
 
         self.connection_kwargs = defaultdict(ConnectionKwargs)
         self.dag = self.build_dag(**kwargs)
@@ -86,72 +87,68 @@ class AWSParamStoreToAirflowDAG:
         :param default_args:
         :return:
         """
-
-        @task
-        def build_param_connections():
-            """
-            Iterate parameter prefixes and build connection objects
-            """
-            for ssm_prefix, api_year in self.prefix_year_mapping:
-                param_store = SSMParameterStore(prefix=ssm_prefix, region_name=self.region_name)
-
-                for param_name in param_store.keys():
-                    # {ssm_prefix}/{tenant_code}/{param_type}
-                    tenant_code, param_type = param_name.replace(ssm_prefix, "").strip('/').split('/')
-
-                    # Translate the tenant-code if provided in the mapping.
-                    tenant_code = self.tenant_mapping.get(tenant_code, tenant_code)
-
-                    # Build the standardized connection ID, then add to the connection kwargs dictionary.
-                    conn_id = f"edfi_{tenant_code}_{api_year}"
-                    self.connection_kwargs[conn_id].add_kwarg(param_type, param_store[param_name])
-
-        @task
-        def upload_param_connections():
-            """
-            Attempt to upload connections to Airflow, warning if already present or incomplete.
-            https://stackoverflow.com/questions/51863881
-            """
-            session = airflow.settings.Session()
-
-            for conn_id, conn_kwargs in self.connection_kwargs.items():
-
-                # Verify whether the connection already exists in Airflow, and continue if not overwriting.
-                if session.query(Connection).filter(Connection.conn_id == conn_id).first():
-
-                    if not self.overwrite:
-                        logging.warning(
-                            f"Failed to import `{conn_id}`: Connection already exists!"
-                        )
-                        continue
-
-                # Try to convert the kwargs into a connection, erroring if missing a required field.
-                try:
-                    conn = conn_kwargs.to_conn(conn_id)
-                except Exception as err:
-                    logging.warning(
-                        f"Failed to import `{conn_id}`: {err}"
-                    )
-                    continue
-
-                # Add the connection
-                session.add(conn)
-                session.commit()
-
-                logging.info(Connection.log_info(conn))
-                logging.info(
-                    f"Connection {conn_id} was added."
-                )
-
-
-        # This syntax ensures param_store stays hidden within the class.
-        # TODO: Is this still true?
         with DAG(
             dag_id=dag_id,
             default_args=default_args,
             catchup=False,
             **kwargs
         ) as dag:
-            build_param_connections() >> upload_param_connections()
+            self.build_param_connections() >> self.upload_param_connections()
 
         return dag
+
+    @task
+    def build_param_connections(self):
+        """
+        Iterate parameter prefixes and build connection objects
+        """
+        for ssm_prefix, api_year in self.prefix_year_mapping.items():
+            param_store = SSMParameterStore(prefix=ssm_prefix, region_name=self.region_name)
+
+            for param_name in param_store.keys():
+                # {ssm_prefix}/{tenant_code}/{param_type}
+                tenant_code, param_type = param_name.replace(ssm_prefix, "").strip('/').split('/')
+
+                # Translate the tenant-code if provided in the mapping.
+                tenant_code = self.tenant_mapping.get(tenant_code, tenant_code)
+
+                # Build the standardized connection ID, then add to the connection kwargs dictionary.
+                conn_id = f"edfi_{tenant_code}_{api_year}"
+                self.connection_kwargs[conn_id].add_kwarg(param_type, param_store[param_name])
+
+    @task
+    def upload_param_connections(self):
+        """
+        Attempt to upload connections to Airflow, warning if already present or incomplete.
+        https://stackoverflow.com/questions/51863881
+        """
+        session = airflow.settings.Session()
+
+        for conn_id, conn_kwargs in self.connection_kwargs.items():
+
+            # Verify whether the connection already exists in Airflow, and continue if not overwriting.
+            if session.query(Connection).filter(Connection.conn_id == conn_id).first():
+
+                if not self.overwrite:
+                    logging.warning(
+                        f"Failed to import `{conn_id}`: Connection already exists!"
+                    )
+                    continue
+
+            # Try to convert the kwargs into a connection, erroring if missing a required field.
+            try:
+                conn = conn_kwargs.to_conn(conn_id)
+            except Exception as err:
+                logging.warning(
+                    f"Failed to import `{conn_id}`: {err}"
+                )
+                continue
+
+            # Add the connection
+            session.add(conn)
+            session.commit()
+
+            logging.info(Connection.log_info(conn))
+            logging.info(
+                f"Connection {conn_id} was added."
+            )

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -106,6 +106,8 @@ class AWSParamStoreToAirflowDAG:
             if self.prefix_year_mapping:
                 self.build_kwargs_from_prefix_year_mapping()
 
+            logging.info(self.connection_kwargs)
+
 
         @task
         def upload_param_connections():

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -142,6 +142,7 @@ class AWSParamStoreToAirflowDAG:
 
             # Add each param to the connection kwargs dictionary.
             for param_type in param_store.keys():
+                logging.info(param_type)
                 self.connection_kwargs[conn_id].add_kwarg(param_type, param_store[param_type])
 
 

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -195,7 +195,6 @@ class AWSParamStoreToAirflowDAG:
             session.add(conn)
             session.commit()
 
-            logging.info(Connection.log_info(conn))
             logging.info(
                 f"Connection {conn_id} was added."
             )

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -140,6 +140,7 @@ class AWSParamStoreToAirflowDAG:
             param_store = SSMParameterStore(prefix=ssm_prefix, region_name=self.region_name)
 
             for param_name in param_store.keys():
+                logging.info(param_name)
                 # {ssm_prefix}/{param_type}
                 param_type = param_name.replace(ssm_prefix, "").strip('/').split('/')[-1]
 
@@ -155,6 +156,7 @@ class AWSParamStoreToAirflowDAG:
             param_store = SSMParameterStore(prefix=ssm_prefix, region_name=self.region_name)
 
             for param_name in param_store.keys():
+                logging.info(param_name)
                 # {ssm_prefix}/{tenant_code}/{param_type}
                 tenant_code, param_type = param_name.replace(ssm_prefix, "").strip('/').split('/')
 

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -65,13 +65,11 @@ class AWSParamStoreToAirflowDAG:
         prefix_year_mapping: Optional[dict] = None,
         tenant_mapping: Optional[str] = None,
 
-        overwrite: bool = False,
         join_numbers: bool = True,
 
         **kwargs
     ):
         self.region_name = region_name
-        self.overwrite = overwrite
         self.join_numbers = join_numbers
 
         self.connection_mapping  = connection_mapping or {}

--- a/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
+++ b/ea_airflow_util/dags/aws_param_store_to_airflow_dag.py
@@ -95,7 +95,7 @@ class AWSParamStoreToAirflowDAG:
             """
             Iterate parameter prefixes and build connection objects
             """
-            if not (self.connection_mapping and self.prefix_year_mapping):
+            if not (self.connection_mapping or self.prefix_year_mapping):
                 raise AirflowFailException(
                     "Neither arguments `connection_mapping` nor `prefix_year_mapping` have been defined."
                 )


### PR DESCRIPTION
This refactors the AWSParamStoreToAirflowDAG to ingest the key/url/secret sub-param format used by the CEI team. There are two types of prefixes that can be defined for a param: `connection_mapping` map prefixes to connections one-to-one , and `prefix_year_mapping` and `tenant_code_mapping` are for dynamic import of multiple params that share the same prefix. Both types have been tested on SCDE and South Carolina respectively.