### PR TITLE
Fix/deprecation warnings

### DIFF
--- a/ea_airflow_util/dags/operators/dbt_operators.py
+++ b/ea_airflow_util/dags/operators/dbt_operators.py
@@ -1,8 +1,7 @@
 # AirflowDBT uses Airflow 1.x syntax when defining Hooks and Operators.
 # These warnings clog up the scheduler and should be hidden until the package is updated.
 import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", module="airflow_dbt", category=DeprecationWarning)
+warnings.filterwarnings("ignore", module="airflow_dbt", category=DeprecationWarning)
 
 from airflow.utils.decorators import apply_defaults
 from airflow_dbt.operators.dbt_operator import DbtBaseOperator

--- a/ea_airflow_util/dags/run_dbt_airflow_dag.py
+++ b/ea_airflow_util/dags/run_dbt_airflow_dag.py
@@ -1,8 +1,7 @@
 # AirflowDBT uses Airflow 1.x syntax when defining Hooks and Operators.
 # These warnings clog up the scheduler and should be hidden until the package is updated.
 import warnings
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", module="airflow_dbt", category=DeprecationWarning)
+warnings.filterwarnings("ignore", module="airflow_dbt", category=DeprecationWarning)
 
 from datetime import datetime
 from functools import partial


### PR DESCRIPTION
The Airflow DBT package uses Airflow 1.x imports and 1.x decorators. These raise DeprecationWarnings that clog up the scheduler logs. Our options are either to recreate the Airflow DBT providers ourselves, or to just suppress the warnings from this package.