### PR TITLE
Feature/external DAG trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ea_airflow_util v0.2.6
 ## New features
-- Add optional `trigger_dag_on_run_success` argument to `RunDbtDag` to trigger external DAG upon completion of `dbt run`.
+- Add optional `trigger_dags_on_run_success` argument to `RunDbtDag` to trigger a list of external DAGs upon completion of `dbt run`.
 
 # ea_airflow_util v0.2.5
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# ea_airflow_util v0.2.6
+## New features
+- Add optional `trigger_dag_on_run_success` argument to `RunDbtDag` to trigger external DAG upon completion of `dbt run`.
+
 # ea_airflow_util v0.2.5
 ## New features
 - Add a dag generator for cleaning up the Airflow database

--- a/README.md
+++ b/README.md
@@ -15,18 +15,19 @@ Additionally, DBT artifacts are optionally uploaded using the [Brooklyn Data dbt
 
 -----
 
-| Argument              | Description                                                                                            |
-|-----------------------|--------------------------------------------------------------------------------------------------------|
-| environment           | environment name for the DAG label                                                                     |
-| dbt_repo_path         | path to the project `/dbt` folder                                                                      |
-| dbt_target_name       | name of the DBT target to select                                                                       |
-| dbt_bin_path          | path to the environment `/dbt` folder                                                                  |
-| full_refresh          | boolean flag for whether to apply the `--full-refresh` flag to incremental models (default `False`)    |
-| full_refresh_schedule | Cron schedule for when to automatically kick off a full refresh run                                    |
-| opt_dest_schema       | optional destination schema to swap target schema with if `opt_swap=True`                              |
-| opt_swap              | boolean flag for whether to swap target schema with `opt_dest_schema` after each run (default `False`) |
-| upload_artifacts      | boolean flag for whether to upload DBT artifacts at the end of the run (default `False`)               |
-| slack_conn_id         | Slack webhook Airflow connection ID for sending run errors to a Slack channel                          |
+| Argument                    | Description                                                                                            |
+|-----------------------------|--------------------------------------------------------------------------------------------------------|
+| environment                 | environment name for the DAG label                                                                     |
+| dbt_repo_path               | path to the project `/dbt` folder                                                                      |
+| dbt_target_name             | name of the DBT target to select                                                                       |
+| dbt_bin_path                | path to the environment `/dbt` folder                                                                  |
+| full_refresh                | boolean flag for whether to apply the `--full-refresh` flag to incremental models (default `False`)    |
+| full_refresh_schedule       | Cron schedule for when to automatically kick off a full refresh run                                    |
+| opt_dest_schema             | optional destination schema to swap target schema with if `opt_swap=True`                              |
+| opt_swap                    | boolean flag for whether to swap target schema with `opt_dest_schema` after each run (default `False`) |
+| upload_artifacts            | boolean flag for whether to upload DBT artifacts at the end of the run (default `False`)               |
+| slack_conn_id               | Slack webhook Airflow connection ID for sending run errors to a Slack channel                          |
+| trigger_dags_on_run_success | optional list of dags to be triggered by a successful dbt_run                                          |
 
 Additional DAG arguments (e.g. `default_args`) can be passed as kwargs.
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='ea_airflow_util',
-      version='0.2.5',
+      version='0.2.6',
       description='EA Airflow tools',
       license_files=['LICENSE'],
       url='https://github.com/edanalytics/ea_airflow_util',


### PR DESCRIPTION
## Description & motivation
Adds the ability to trigger external DAGs after `dbt_run` finishes by supplying an optional `trigger_dags_on_run_success` list argument. These are downstream of `dbt_run` but not `dbt_test`, ensuring that they will run even if `dbt_test` fails.

## Tests and QC done:
Tested in Jeffco with two downstream DAGs:
`trigger_dags_on_run_success: ['IC_load_dag', 'salesforce_sync']`
![image](https://github.com/edanalytics/ea_airflow_util/assets/56237580/a2f8edb3-9f6a-468c-8a34-d7d36531bf7d)

## PR Merge Priority:
- High
