### PR TITLE
Hotfix/ea custom dag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# ea_airflow_util v0.3.1
+## Fixes
+- Fix bug in `EACustomDAG` where `default_args` were not passed to DAG super init.
+
 # ea_airflow_util v0.3.0
 ## New features
 - Migrate FTP, ShareFile, casing, and ZIP utilities from Rally into `ea_airflow_util`

--- a/ea_airflow_util/dags/ea_custom_dag.py
+++ b/ea_airflow_util/dags/ea_custom_dag.py
@@ -55,6 +55,7 @@ class EACustomDAG(DAG):
             catchup=catchup,
             render_template_as_native_obj=render_template_as_native_obj,
             max_active_runs=max_active_runs,
+            default_args=default_args,
             user_defined_macros=user_defined_macros,
             sla_miss_callback=slack_sla_miss_callback,
             **self.subset_kwargs_to_class(DAG, kwargs)  # Remove kwargs not expected in DAG.


### PR DESCRIPTION
This PR fixes a bug where `default_args` was missed in EACustomDAG's super init.