### PR TITLE
Feature/File Type Conversion/XML to JSON

### DIFF
--- a/ea_airflow_util/callables/file_type.py
+++ b/ea_airflow_util/callables/file_type.py
@@ -1,0 +1,48 @@
+import json
+import xmltodict
+import os 
+import logging
+    
+def xml_to_json(
+    xml_path: str,
+    output_path: str = None
+):
+    """
+    Transform an XML file into a JSON format.
+    """    
+    
+    try:
+        ### Open the input XML file and read data in form of python dictionary using xmltodict module.
+        with open(xml_path) as xml_file:
+            data_dict = xmltodict.parse(xml_file.read())
+    except FileNotFoundError as error:
+        logging.error(f"Error: {str(error)} (XML file not found)")
+    except Exception as error:
+        logging.error(f"Error: {str(error)}")
+      
+    ### Generate the object using json.dumps() corresponding to JSON data.
+    json_data = json.dumps(data_dict)
+
+    ### Check if output_path is provided, otherwise set it to a default value (XML folder path).
+    if output_path is None:
+        output_path = os.path.dirname(xml_path)
+        output_directory = f'{output_path}/json'
+    else:
+        output_directory = f'{output_path}/json'
+
+    ### Set the name of the json file to the name of the XML file provided.
+    file_name = os.path.splitext(os.path.basename(xml_path))[0]
+        
+    ### Create the output directory if it doesn't exist.
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
+
+    ### Write the contents of the JSON file into the folder path with a progress bar.
+    file_path = os.path.join(output_directory, f'{file_name}.json')
+    try:
+        with open(file_path, "w") as json_file:
+            json_file.write(json_data)
+    except Exception as error:
+        logging.error(f"Error: {str(error)}")
+        
+    return json_data

--- a/ea_airflow_util/callables/file_type.py
+++ b/ea_airflow_util/callables/file_type.py
@@ -11,8 +11,8 @@ def xml_to_json(
     Transform an XML file into a JSON format.
     """    
     
+    # Open the input XML file and read data in form of python dictionary using xmltodict module.
     try:
-        ### Open the input XML file and read data in form of python dictionary using xmltodict module.
         with open(xml_path) as xml_file:
             data_dict = xmltodict.parse(xml_file.read())
     except FileNotFoundError as error:
@@ -20,24 +20,24 @@ def xml_to_json(
     except Exception as error:
         logging.error(f"Error: {str(error)}")
       
-    ### Generate the object using json.dumps() corresponding to JSON data.
+    # Generate the object using json.dumps() corresponding to JSON data.
     json_data = json.dumps(data_dict)
 
-    ### Check if output_path is provided, otherwise set it to a default value (XML folder path).
+    # Check if output_path is provided, otherwise set it to a default value (XML folder path).
     if output_path is None:
         output_path = os.path.dirname(xml_path)
         output_directory = f'{output_path}/json'
     else:
         output_directory = f'{output_path}/json'
 
-    ### Set the name of the json file to the name of the XML file provided.
+    # Set the name of the json file to the name of the XML file provided.
     file_name = os.path.splitext(os.path.basename(xml_path))[0]
         
-    ### Create the output directory if it doesn't exist.
+    # Create the output directory if it doesn't exist.
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
 
-    ### Write the contents of the JSON file into the folder path with a progress bar.
+    # Write the contents of the JSON file into the folder path with a progress bar.
     file_path = os.path.join(output_directory, f'{file_name}.json')
     try:
         with open(file_path, "w") as json_file:


### PR DESCRIPTION
## Description & motivation
While developing an Earthmover Template for Stadium Texas’ HRIS Staff Data, we encountered challenges with Earthmover’s ability to parse variables within non-flattened XML files. To address this, we created a Python script that converts nested XML files into JSON format. After some consideration, we felt that this script general enough that it can be used by other projects, and thus thought it would be a good opportunity to include this in our `EA_airflow_util` repo.

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## New files created:
- `file_type.py`: Not sure if the name of this model is the one we want to go with, but something longer like "`file_type_conversion.py`" felt out of place given the short and straightforward names in the other files.

## Tests and QC done:
- Ran this script for Stadium Texas' HRIS Staff Data loading on Earthmover successfully.