### PR TITLE
Feature/Sharefile custom users DAG & S3 to Snowflake standardization

### DIFF
--- a/ea_airflow_util/callables/s3.py
+++ b/ea_airflow_util/callables/s3.py
@@ -155,3 +155,17 @@ def list_s3_keys(
 
     # Remove directories and return.
     return [subkey for subkey in subkeys if not subkey.endswith("/")]
+
+
+def delete_from_s3(
+    s3_conn_id: str,
+    s3_keys_to_delete: List[str]
+):
+    """
+    Delete a list of S3 objects
+    """
+    s3_hook = S3Hook(aws_conn_id=s3_conn_id)
+
+    logging.info('Deleting file from source s3')
+
+    s3_hook.delete_objects(bucket=s3_hook.get_connection(s3_conn_id).schema, keys=s3_keys_to_delete)

--- a/ea_airflow_util/callables/sharefile.py
+++ b/ea_airflow_util/callables/sharefile.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pytz
 import re
 import requests
 
@@ -155,7 +156,8 @@ def check_for_new_files(sharefile_conn_id: str, sharefile_path: str, expected_fi
     new_file_count = 0
 
     for file in sf_all_files:
-        if updated_after == 'None' or file['CreationDate'] >= updated_after:
+        file_updated_time = datetime.strptime(file['CreationDate'], '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=pytz.UTC)
+        if updated_after == 'None' or file_updated_time >= updated_after:
             new_file_count += 1
 
     if new_file_count == 0:

--- a/ea_airflow_util/dags/s3_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/s3_to_snowflake_dag.py
@@ -1,18 +1,14 @@
-import logging
 import os
 
-from typing import Optional
-
 from airflow.operators.python_operator import PythonOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
-from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.utils.helpers import chain
 
 
 from ea_airflow_util.dags.ea_custom_dag import EACustomDAG
 from ea_airflow_util.callables.airflow import xcom_pull_template
-from ea_airflow_util.providers.aws.operators.s3 import LoopS3FileTransformOperator
+from ea_airflow_util.callables import s3
+from ea_airflow_util.providers.aws.operators.s3 import LoopS3FileTransformOperator, S3ToSnowflakeOperator
 
 
 class S3ToSnowflakeDag:
@@ -119,14 +115,20 @@ class S3ToSnowflakeDag:
                 transfer_s3_to_s3 = None
 
             ## Copy data from dest bucket (data lake stage) to snowflake raw table
-            copy_to_raw = PythonOperator(
+            copy_to_raw = S3ToSnowflakeOperator(
                 task_id=f'copy_to_raw_{resource_name}',
-                python_callable=self.copy_from_datalake_to_raw,
-                op_kwargs={
-                    'resource_name': resource_name,
-                    'datalake_prefix': datalake_prefix,
-                    'full_replace': self.full_replace
+                snowflake_conn_id=self.snowflake_conn_id,
+                database=self.database,
+                schema=self.schema,
+                table_name=f'{self.data_source}__{resource_name}',
+                custom_metadata_columns={
+                    'tenant_code': f"'{self.tenant_code}'",
+                    'api_year': f"'{self.api_year}'",
+                    'resource_name': f"'{resource_name}'"
                 },
+                s3_destination_key=datalake_prefix,
+                full_refresh=self.full_replace,
+                delete_where=f"where tenant_code = '{self.tenant_code}' and api_year = '{self.api_year}'",
                 dag=self.dag
             )
 
@@ -134,9 +136,10 @@ class S3ToSnowflakeDag:
             if self.s3_dest_conn_id and self.do_delete_from_source:
                 delete_from_source = PythonOperator(
                     task_id=f'delete_from_source_{resource_name}',
-                    python_callable=self.delete_from_source,
+                    python_callable=s3.delete_from_s3,
                     op_kwargs={
-                        's3_source_keys'  : xcom_pull_template(list_s3_objects.task_id)
+                        's3_conn_id': self.s3_source_conn_id,
+                        's3_keys_to_delete': xcom_pull_template(list_s3_objects.task_id)
                     },
                     dag=self.dag
                 )
@@ -152,61 +155,3 @@ class S3ToSnowflakeDag:
             )
 
             chain(*filter(None, task_order))  # Chain all defined operators into task-order.
-
-
-    def copy_from_datalake_to_raw(self, resource_name, datalake_prefix, full_replace):
-        """
-        Copy raw data from data lake to data warehouse, including object metadata.
-        """
-
-        delete_sql = f'''
-            delete from {self.database}.{self.schema}.{self.data_source}__{resource_name}
-            where tenant_code = '{self.tenant_code}'
-              and api_year = '{self.api_year}'
-        '''
-
-        date_regex = "\\\\d{8}"
-        ts_regex = "\\\\d{8}T\\\\d{6}"
-
-        
-        logging.info(f"Copying from data lake to raw: {datalake_prefix}")
-        copy_sql = f'''
-            copy into {self.database}.{self.schema}.{self.data_source}__{resource_name}
-                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, v)
-            from (
-                select
-                    '{self.tenant_code}' as tenant_code,
-                    '{self.api_year}' as api_year,
-                    TO_DATE(REGEXP_SUBSTR(metadata$filename, '{date_regex}'), 'YYYYMMDD') AS pull_date,
-                    TO_TIMESTAMP(REGEXP_SUBSTR(metadata$filename, '{ts_regex}'), 'YYYYMMDDTHH24MISS') AS pull_timestamp,
-                    metadata$file_row_number as file_row_number,
-                    metadata$filename as filename,
-                    '{resource_name}' as name,
-                    t.$1 as v
-                from @{self.database}.util.airflow_stage/{datalake_prefix}/
-                (file_format => 'json_default') t
-            ) FORCE=TRUE
-        '''
-
-        # Commit the copy query to Snowflake
-        snowflake_hook = SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id)
-
-        if full_replace:
-            cursor_log_delete = snowflake_hook.run(sql=delete_sql)
-            logging.info(cursor_log_delete)
-
-        cursor_log_copy = snowflake_hook.run(sql=copy_sql)
-
-        #TODO look into ways to return copy metadata (n rows copied, n failures, etc.) right now it just says "1 row affected"
-        logging.info(cursor_log_copy)
-
-
-    def delete_from_source(self, s3_source_keys):
-        """
-        Delete the object from the source bucket.
-        """
-        s3_source_hook = S3Hook(aws_conn_id=self.s3_source_conn_id)
-
-        logging.info('Deleting file from source s3')
-
-        s3_source_hook.delete_objects(bucket=s3_source_hook.get_connection(self.s3_source_conn_id).schema, keys=s3_source_keys)

--- a/ea_airflow_util/dags/s3_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/s3_to_snowflake_dag.py
@@ -124,7 +124,7 @@ class S3ToSnowflakeDag:
                 custom_metadata_columns={
                     'tenant_code': f"'{self.tenant_code}'",
                     'api_year': f"'{self.api_year}'",
-                    'resource_name': f"'{resource_name}'"
+                    'name': f"'{resource_name}'"
                 },
                 s3_destination_key=datalake_prefix,
                 full_refresh=self.full_replace,

--- a/ea_airflow_util/dags/sftp_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/sftp_to_snowflake_dag.py
@@ -149,7 +149,7 @@ class SFTPToSnowflakeDag:
                 custom_metadata_columns={
                     'tenant_code': f"'{tenant_code}'",
                     'api_year': f"'{api_year}'",
-                    'resource_name': f"'{resource_name}'"
+                    'name': f"'{resource_name}'"
                 },
                 s3_destination_key=datalake_date_path,
                 full_refresh=full_replace,

--- a/ea_airflow_util/dags/sftp_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/sftp_to_snowflake_dag.py
@@ -9,10 +9,10 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.providers.sftp.hooks.sftp import SFTPHook
-from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.utils.task_group import TaskGroup
 
 from ea_airflow_util.dags.ea_custom_dag import EACustomDAG
+from ea_airflow_util.providers.aws.operators.s3 import S3ToSnowflakeOperator
 
 
 class SFTPToSnowflakeDag:
@@ -140,7 +140,7 @@ class SFTPToSnowflakeDag:
             )
 
             ## Copy data from dest bucket (data lake stage) to snowflake raw table
-            copy_to_raw = PythonOperator(
+            copy_to_raw = S3ToSnowflakeOperator(
                 task_id=f'{taskgroup_grain}_copy_to_raw',
                 snowflake_conn_id=self.snowflake_conn_id,
                 database=self.database,

--- a/ea_airflow_util/dags/sftp_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/sftp_to_snowflake_dag.py
@@ -142,16 +142,18 @@ class SFTPToSnowflakeDag:
             ## Copy data from dest bucket (data lake stage) to snowflake raw table
             copy_to_raw = PythonOperator(
                 task_id=f'{taskgroup_grain}_copy_to_raw',
-                python_callable=self.copy_from_datalake_to_raw,
-                op_kwargs={
-                    'datalake_date_path': datalake_date_path,
-                    'domain': domain,
-                    'tenant_code': tenant_code,
-                    'api_year': api_year,
-                    'resource_name': resource_name,
-                    'full_replace': full_replace
+                snowflake_conn_id=self.snowflake_conn_id,
+                database=self.database,
+                schema=self.schema,
+                table_name=f'{domain}__{resource_name}',
+                custom_metadata_columns={
+                    'tenant_code': f"'{tenant_code}'",
+                    'api_year': f"'{api_year}'",
+                    'resource_name': f"'{resource_name}'"
                 },
-                pool=self.pool,
+                s3_destination_key=datalake_date_path,
+                full_refresh=full_replace,
+                delete_where=f"where tenant_code = '{tenant_code}' and api_year = '{api_year}'",
                 dag=self.dag
             )
 
@@ -269,56 +271,6 @@ class SFTPToSnowflakeDag:
             )
 
         return s3_destination_key
-    
-    
-    def copy_from_datalake_to_raw(self, datalake_date_path, domain, tenant_code, api_year, resource_name, full_replace):
-        """
-        Copy raw data from data lake to data warehouse, including object metadata.
-        
-        :param datalake_date_path:  
-        :param domain
-        :param tenant_code
-        :param api_year
-        :param resource_name
-        :param full_replace
-        :return:
-        """
-        delete_sql = f'''
-            delete from {self.database}.{self.schema}.{domain}__{resource_name}
-            where tenant_code = '{tenant_code}'
-              and api_year = '{api_year}'
-        '''
-
-        logging.info(f"Copying from data lake to raw: {datalake_date_path}")
-        copy_sql = f'''
-            copy into {self.database}.{self.schema}.{domain}__{resource_name}
-                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, v)
-            from (
-                select
-                    '{tenant_code}' as tenant_code,
-                    '{api_year}' as api_year,
-                    to_date(split_part(metadata$filename, '/', 3), 'YYYYMMDD') as pull_date,
-                    to_timestamp(split_part(metadata$filename, '/', 4), 'YYYYMMDDTHH24MISS') as pull_timestamp,
-                    metadata$file_row_number as file_row_number,
-                    metadata$filename as filename,
-                    '{resource_name}' as name,
-                    t.$1 as v
-                from @{self.database}.util.airflow_stage/{datalake_date_path}/
-                (file_format => 'json_default') t
-            ) FORCE=TRUE
-        '''
-
-        # Commit the copy query to Snowflake
-        snowflake_hook = SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id)
-
-        if full_replace:
-            cursor_log_delete = snowflake_hook.run(sql=delete_sql)
-            logging.info(cursor_log_delete)
-
-        cursor_log_copy = snowflake_hook.run(sql=copy_sql)
-
-        #TODO look into ways to return copy metadata (n rows copied, n failures, etc.) right now it just says "1 row affected"
-        logging.info(cursor_log_copy)
 
 
     def delete_from_local(self, parent_to_delete):

--- a/ea_airflow_util/dags/sharefile_custom_users_dag.py
+++ b/ea_airflow_util/dags/sharefile_custom_users_dag.py
@@ -86,7 +86,7 @@ class LoadSharefileCustomUsersDag:
                     op_kwargs       = {
                         'sharefile_conn_id': self.sharefile_conn_id,
                         'sharefile_path'   : os.path.join(self.sharefile_base_path, tenant),
-                        'expected_files'   : 1,
+                        'num_expected_files'   : 1,
                         'updated_after'    : '{{prev_data_interval_start_success}}'
                     },
                     dag=self.dag

--- a/ea_airflow_util/dags/sharefile_custom_users_dag.py
+++ b/ea_airflow_util/dags/sharefile_custom_users_dag.py
@@ -1,0 +1,175 @@
+import os
+from typing import List
+
+from airflow.utils.task_group import TaskGroup
+from airflow.operators.python import PythonOperator
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow_dbt.operators.dbt_operator import DbtRunOperator
+
+from ea_airflow_util.callables.airflow import xcom_pull_template
+from ea_airflow_util.callables import jsonl, s3, sharefile
+from ea_airflow_util.dags.ea_custom_dag import EACustomDAG
+from ea_airflow_util.providers.sharefile.transfers.sharefile_to_disk import SharefileToDiskOperator
+from ea_airflow_util.providers.aws.operators.s3 import S3ToSnowflakeOperator
+
+
+class LoadSharefileCustomUsersDag:
+    """
+
+    """    
+    def __init__(self,
+        *,
+        tenant_codes: List[str],
+        sharefile_conn_id: str,
+        sharefile_base_path: str,
+        tmp_dir: str,
+        colnames: List[str],
+
+        s3_conn_id: str,
+        s3_base_dir: str,
+        s3_bucket: str,
+
+        snowflake_conn_id: str,
+        snowflake_database: str,
+        snowflake_schema: str,
+        snowflake_table: str,
+
+        dbt_repo_path: str,
+        dbt_target_name: str,
+        dbt_bin_path: str,
+
+        heimdall_dag_id: str = None,
+        delete_remote: bool = False,
+        **kwargs
+    ) -> None:
+        self.tenant_codes = tenant_codes
+        self.sharefile_conn_id = sharefile_conn_id
+        self.sharefile_base_path = sharefile_base_path
+        self.tmp_dir = tmp_dir
+        self.colnames = colnames
+
+        self.s3_conn_id = s3_conn_id
+        self.s3_base_dir = s3_base_dir
+        self.s3_bucket = s3_bucket
+
+        self.snowflake_conn_id = snowflake_conn_id
+        self.snowflake_database = snowflake_database
+        self.snowflake_schema = snowflake_schema
+        self.snowflake_table = snowflake_table
+
+        self.dbt_repo_path = dbt_repo_path
+        self.dbt_target_name = dbt_target_name
+        self.dbt_bin_path = dbt_bin_path
+
+        self.heimdall_dag_id = heimdall_dag_id
+        self.delete_remote = delete_remote
+
+        self.dag = EACustomDAG(**kwargs)
+        
+    def build_sharefile_custom_users_dag(self, **kwargs):
+
+        extract_load_taskgroups = []
+        for tenant in self.tenant_codes:
+
+            with TaskGroup(
+                group_id=tenant,
+                dag=self.dag
+            ) as tenant_task_group:
+
+                # Checks that the folder exists and contains a file that has been uploaded or modified since the last successful run
+                # If the dag is reset and previous runs are lost, all files will be loaded. Models have deduplication to handle this
+                # Skips if no new files are found
+                # Fails if more than one file is found (according to PS desired bahavior)
+                check_for_new_files = PythonOperator(
+                    task_id         = f"check_for_new_files",
+                    python_callable = sharefile.check_for_new_files,
+                    op_kwargs       = {
+                        'sharefile_conn_id': self.sharefile_conn_id,
+                        'sharefile_path'   : os.path.join(self.sharefile_base_path, tenant),
+                        'expected_files'   : 1,
+                        'updated_after'    : '{{prev_data_interval_start_success}}'
+                    },
+                    dag=self.dag
+                )
+
+                ### ShareFile to Disk
+                sharefile_to_disk = SharefileToDiskOperator(
+                    task_id           = f"{tenant}_sharefile_to_disk",
+                    sharefile_conn_id = self.sharefile_conn_id,
+                    sharefile_path    = os.path.join(self.sharefile_base_path, tenant),
+                    local_path        = os.path.join(self.tmp_dir, self.s3_base_dir, '{{ds_nodash}}', '{{ts_nodash}}', tenant),
+                    delete_remote     = self.delete_remote,
+                    retries           = 3,
+                    dag=self.dag
+                )
+
+                ### Translate CSV to JSONL
+                transform_to_jsonl = PythonOperator(
+                    task_id         = f"{tenant}_csv_to_jsonl",
+                    python_callable = jsonl.translate_csv_file_to_jsonl,
+                    op_kwargs       = {
+                        'local_path'   : xcom_pull_template(sharefile_to_disk),
+                        'output_path'  : None,
+                        'to_snake_case': True,
+                        'delete_csv'   : True,
+                    },
+                    dag=self.dag
+                )
+
+                ### Disk to S3
+                disk_to_s3 = PythonOperator(
+                    task_id         = f"{tenant}_disk_to_s3",
+                    python_callable = s3.disk_to_s3,
+                    op_kwargs       = {
+                        's3_conn_id'  : self.s3_conn_id,
+                        'bucket'      : self.s3_bucket,
+                        'base_dir'    : self.tmp_dir,
+                        'local_path'  : xcom_pull_template(transform_to_jsonl),
+                        'delete_local': True,
+                        'expected_col_names': self.colnames,
+                    },
+                    dag=self.dag
+                )
+
+                ### S3 to Snowflake
+                s3_to_snowflake = S3ToSnowflakeOperator(
+                    task_id                 = f"{tenant}_s3_to_snowflake",
+                    snowflake_conn_id       = self.snowflake_conn_id,
+                    database                = self.snowflake_database,
+                    schema                  = self.snowflake_schema,
+                    table_name              = self.snowflake_table,
+                    custom_metadata_columns = {'tenant_code': f"'{tenant}'"},
+                    s3_destination_key      = xcom_pull_template(disk_to_s3),
+                    full_refresh            = False,
+                    dag=self.dag
+                )
+
+                check_for_new_files >> sharefile_to_disk >> transform_to_jsonl >> disk_to_s3 >> s3_to_snowflake
+
+                extract_load_taskgroups.append(tenant_task_group)
+
+        ### Partial dbt run to update the custom user security table
+        run_dbt_security_table = DbtRunOperator(
+            task_id      = 'run_dbt_security_table',
+            dir          = self.dbt_repo_path,
+            target       = self.dbt_target_name,
+            dbt_bin      = self.dbt_bin_path,
+            models       = '+stg_auth__heimdall_custom_users+',
+            trigger_rule = 'all_done',
+            dag=self.dag
+        )
+
+        ### Trigger the Heimdall dag (prod only)
+        if self.heimdall_dag_id is not None:
+            trigger_heimdall_dag = TriggerDagRunOperator(
+                task_id             = 'trigger_heimdall_dag',
+                trigger_dag_id      = self.heimdall_dag_id,
+                wait_for_completion = False, 
+                trigger_rule        = 'all_done',
+                dag=self.dag
+            )
+
+            extract_load_taskgroups >> run_dbt_security_table >> trigger_heimdall_dag
+
+        else:
+            extract_load_taskgroups >> run_dbt_security_table

--- a/ea_airflow_util/providers/aws/operators/s3.py
+++ b/ea_airflow_util/providers/aws/operators/s3.py
@@ -2,11 +2,13 @@ import os
 import pathlib
 import sys
 
-from typing import List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from airflow.utils.decorators import apply_defaults
 
 
 class LoopS3FileTransformOperator(S3FileTransformOperator):
@@ -93,3 +95,114 @@ class LoopS3FileTransformOperator(S3FileTransformOperator):
             transferred_keys.append(self.dest_s3_key)
 
         return transferred_keys
+    
+
+class S3ToSnowflakeOperator(BaseOperator):
+    """
+    Copy JSON files saved to S3 to Snowflake raw tables.
+
+    The optional custom_metadata_columns param takes a dictionary in the format {alias: value}
+    """
+    template_fields = ('s3_destination_key', 's3_destination_dir', 's3_destination_filename',)
+
+    @apply_defaults
+    def __init__(self,
+        *,
+        snowflake_conn_id: str,
+        database: str,
+        schema: str,
+        table_name: str,
+        custom_metadata_columns: Optional[dict] = None,
+
+        s3_destination_key: Optional[str] = None,
+        s3_destination_dir: Optional[str] = None,
+        s3_destination_filename: Optional[str] = None,
+
+        full_refresh: bool = False,
+        delete_where: Optional[str] = None,
+        xcom_return: Optional[Any] = None,
+        **kwargs
+    ) -> None:
+        super(S3ToSnowflakeOperator, self).__init__(**kwargs)
+
+        self.snowflake_conn_id = snowflake_conn_id
+        self.database = database
+        self.schema = schema
+        self.table_name = table_name
+        self.custom_metadata_columns = custom_metadata_columns
+
+        self.s3_destination_key = s3_destination_key
+        self.s3_destination_dir = s3_destination_dir
+        self.s3_destination_filename = s3_destination_filename
+
+        self.full_refresh = full_refresh
+        self.delete_where = delete_where
+        self.xcom_return = xcom_return
+
+
+    def execute(self, context):
+        """
+
+        :param context:
+        :return:
+        """
+        snowflake_hook = SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id)
+
+        ### Optionally set destination key by concatting separate args for dir and filename
+        if not self.s3_destination_key:
+            if not (self.s3_destination_dir and self.s3_destination_filename):
+                raise ValueError(
+                    f"Argument `s3_destination_key` has not been specified, and `s3_destination_dir` or `s3_destination_filename` is missing."
+                )
+            self.s3_destination_key = os.path.join(self.s3_destination_dir, self.s3_destination_filename)
+
+        ### Extract column name and select statement string from custom metadata dictionary
+        if self.custom_metadata_columns:
+            column_names_str = ", ".join(self.custom_metadata_columns.keys()) + ","
+            metadata_columns = ", ".join(
+                f"{value} as {alias}"
+                for alias, value in self.custom_metadata_columns.items()
+            ) + ","
+        else:
+            column_names_str = None
+            metadata_columns = None
+
+        ### Build the SQL queries to be passed into `Hook.run()`.
+        qry_delete = f"""
+            DELETE FROM {self.database}.{self.schema}.{self.table_name}
+            {self.delete_where}
+        """
+
+        # Brackets in regex conflict with string formatting.
+        date_regex = "\\\\d{8}"
+        ts_regex   = "\\\\d{8}T\\\\d{6}"
+
+        qry_copy_into = f"""
+            COPY INTO {self.database}.{self.schema}.{self.table_name}
+                (pull_date, pull_timestamp, file_row_number, filename, {column_names_str} v)
+            FROM (
+                SELECT
+                    TO_DATE(REGEXP_SUBSTR(metadata$filename, '{date_regex}'), 'YYYYMMDD') AS pull_date,
+                    TO_TIMESTAMP(REGEXP_SUBSTR(metadata$filename, '{ts_regex}'), 'YYYYMMDDTHH24MISS') AS pull_timestamp,
+                    metadata$file_row_number AS file_row_number,
+                    metadata$filename AS filename,
+                    {metadata_columns}
+                    t.$1 AS v
+                FROM @{self.database}.util.airflow_stage/{self.s3_destination_key}
+                (file_format => 'json_default') t
+            )
+            force = true;
+        """
+
+        ### Commit the update queries to Snowflake.
+        if self.full_refresh:
+            snowflake_hook.run(
+                sql=[qry_delete, qry_copy_into],
+                autocommit=False
+            )
+        else:
+            snowflake_hook.run(
+                sql=qry_copy_into
+            )
+
+        return self.xcom_return


### PR DESCRIPTION
## Description & motivation
This PR adds the `LoadSharefileCustomUsers` DAG that was first implemented in South Carolina. It includes a few helper functions & operators:
- `callables.sharefile.check_for_new_files()` - Verifies that a Sharefile location contains the expected number of files and raises a skip exception if none of them have been added/updated since the specified datetime
- `providers.aws.operators.s3.S3ToSnowflakeOperator` - A version of this code existed in the `SFTPToSnowflakeDAG` and `S3ToSnowflakeDAG`. I added a slightly more flexible version as an operator and refactored these two DAGs to use the standardized version.
- In refactoring the `S3ToSnowflakeDAG`, I moved its last remaining helper function to `callables.s3.delete_from_s3`

## Tests and QC done:
- Ran the `LoadSharefileCustomUsers` DAG successfully in SC dev. 
- Tested that the SFTPToSnowflake DAG works without changes in GSN
- Tested that the S3ToSnowflake DAG works without change in Boston

## PR Merge Priority:
- Medium: this will be needed in INsite soon 