### PR TITLE
Callable: S3 to Sharefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+## New features
+- Add `s3_to_sharefile` and `disk_to_sharefile` callables
+- Add methods to the `SharefileHook`
+
 # ea_airflow_util v0.3.1
 ## New features
 - Boolean argument `is_manual_upload` in `S3ToSnowflakeDag` rearranges S3 source pathing to easier structure for partners

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Helpers when interfacing with Sharefile
 ### list_sharefile_objects(sharefile_conn_id, remote_dir)
 List object names in a specified Sharefile directory.
 
+### sharefile_to_disk(sharefile_conn_id, sharefile_path, local_path, ds_nodash, ts_nodash, delete_remote=False, file_pattern=None)
+Transfer all files from a ShareFile folder to a local date-stamped directory, optionally deleting the remote copy.
+
+### disk_to_sharefile(sf_conn_id, sf_folder_path, local_path)
+Post a file or the contents of a directory to the specified Sharefile folder
+
+### s3_to_sharefile(s3_conn_id, s3_key, sf_conn_id, sf_folder_path):
+Copy a single file from S3 to Sharefile
+
 -----
 
 </details>
@@ -699,10 +708,13 @@ Note that the connection in Airflow must be configured in an unusual way:
 Methods:
 - get_conn()
 - download(item_id, local_path)
+- upload_file(folder_id, local_file)
+- folder_id_from_path(folder_path)
 - delete(item_id)
 - get_path_id(path)
 - item_info(id)
 - find_files(folder_id)
+- find_folders(folder_id)
 - get_access_controls(item_id)
 - get_user(user_id)
 - get_children(item_id)

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -1,4 +1,6 @@
 import io
+from pathlib import Path
+
 import requests
 
 from airflow.hooks.base import BaseHook
@@ -77,25 +79,42 @@ class SharefileHook(BaseHook):
             self.log.error('Item request failed with status code: {}'.format(dl_response.status_code))
             raise AirflowException
 
-    def upload_file(self, sharefile_folder, local_file):
+    def upload_file(self, folder_id, local_file):
         # establish a session if we don't already have one
         if not self.session:
             self.get_conn()
 
-        # sharefile's upload logic is weird
+        # referencing sharefile's upload logic here
         # https://api.sharefile.com/samples/python
-        # TODO: can I do this with a normal post?
+        upload_config_uri = f"{self.base_url}/Items({folder_id})/Upload"
+        upload_config_resp = self.session.get(upload_config_uri)
+        upload_config = upload_config_resp.json()
+    
+        upload_uri = ""
+        try:
+            upload_uri = upload_config["ChunkUri"]
+        except KeyError:
+            # most likely an invalid or nonexistent folder ID
+            raise AirflowException(f"Failed to get upload link for {local_file}; Reason: {upload_config['reason']}; Message: {upload_config['message']['value']}")
 
-        upload_static_uri = f"{self.base_url}/Items({sharefile_folder})/Upload"
+        files = {Path(local_file).name: open(local_file, 'rb')}
+        resp = self.session.post(upload_uri, files=files)
+        resp.raise_for_status()
 
-        upload_uri_resp = self.session.get(upload_static_uri)
-        upload_config = upload_uri_resp.json()
-        upload_static_uri = upload_config["ChunkUri"]
 
-        # TODO: read mode?
-        # TODO: file name...
-        files = {'file': open(local_file, 'rb')}
-        self.session.post(upload_static_uri)
+    def folder_id_from_path(self, folder_path):
+        """Given a complete Sharefile folder path, returns the ID of the leaf folder. If the path is not found, returns `None`"""
+        folders = self.find_folders("allshared")
+
+        result = None
+        for folder in folders:
+            # special handling for folders just under th root
+            test_path = f"{folder['ParentSemanticPath']}/{folder['DisplayName']}" if folder['ParentSemanticPath'] != '/' else f"/{folder['DisplayName']}"
+            if test_path == folder_path:
+                result = folder["ItemID"]
+                break
+
+        return result
 
     def delete(self, item_id):
         # establish a session if we don't already have one
@@ -137,16 +156,21 @@ class SharefileHook(BaseHook):
 
         return results
 
+    def find_folders(self, folder_id):
+        return self._find_items(folder_id, "Folder")
+
+    def find_files(self, folder_id):
+        return self._find_items(folder_id, "File")
 
     ## this method started returning inconsistent results
     # specifically: the parentSemanticPath would sometimes be IDs rather than names
     # hence we switched to the below simplesearch method
-    def find_files(self, folder_id):
+    def _find_items(self, folder_id, item_type):
         if not self.session:
             self.get_conn()
         qry = {
             "Query": {
-                "ItemType": "File",
+                "ItemType": item_type,
                 "ParentID": folder_id
             },
             "Paging": {

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -89,7 +89,7 @@ class SharefileHook(BaseHook):
         upload_config_resp = self.session.get(upload_config_uri)
         upload_config = upload_config_resp.json()
     
-        upload_uri = ""
+        upload_uri = None
         try:
             upload_uri = upload_config["ChunkUri"]
         except KeyError:

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -77,6 +77,26 @@ class SharefileHook(BaseHook):
             self.log.error('Item request failed with status code: {}'.format(dl_response.status_code))
             raise AirflowException
 
+    def upload_file(self, sharefile_folder, local_file):
+        # establish a session if we don't already have one
+        if not self.session:
+            self.get_conn()
+
+        # sharefile's upload logic is weird
+        # https://api.sharefile.com/samples/python
+        # TODO: can I do this with a normal post?
+
+        upload_static_uri = f"{self.base_url}/Items({sharefile_folder})/Upload"
+
+        upload_uri_resp = self.session.get(upload_static_uri)
+        upload_config = upload_uri_resp.json()
+        upload_static_uri = upload_config["ChunkUri"]
+
+        # TODO: read mode?
+        # TODO: file name...
+        files = {'file': open(local_file, 'rb')}
+        self.session.post(upload_static_uri)
+
     def delete(self, item_id):
         # establish a session if we don't already have one
         if not self.session:

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -103,9 +103,11 @@ class SharefileHook(BaseHook):
 
     def folder_id_from_path(self, folder_path):
         """Given a complete Sharefile folder path, returns the ID of the leaf folder. If the path is not found, returns `None`"""
-        # Sharefile's documentation doesn't explicitly describe how "allshared" is supposed to be used,
-        #    but it appears to be a stand-in for "root." By searching for all folders underneath "allshared"
+        # "allshared" is a Sharefile-specific "special ID." According to the docs, it is used to 
+        #    "Return parent Shared Folders item." Based on their examples and our own experimentation,
+        #    it appears to be a stand-in for "root." By searching for all folders underneath "allshared"
         #    we should get a list of every folder in the hierarchy (including nested ones)
+        # ref: https://api.sharefile.com/docs/resource?name=Items
         # ref: https://api.sharefile.com/samples/python
         folders = self.find_folders("allshared")
 


### PR DESCRIPTION
Adds an `s3_to_sharefile` callable and supporting methods. This could be used to share artifacts of DAG runs with partners.

### Usage
```python
from ea_airflow_util.callables.sharefile import s3_to_sharefile

op = PythonOperator(
    task_id=...,
    dag=...,
    python_callable=s3_to_sharefile,
    op_kwargs={
        "s3_conn_id": "<connection ID>",
        "s3_key": "path/to/file.csv",
        "sf_conn_id": "<connection ID>",
        "sf_folder_path": "/path/to/folder",
    },
)
```

### Other additions
Includes a `disk_to_sharefile` callable that accepts file or directory uplaods

Additionally adds methods to the `SharefileHook` for navigating folders and uploading files.

### Testing
This code was tested on a dev server and successfully copied files from S3 to Sharefile.