### PR TITLE
Hotfix: Sharefile Custom Users Missing Init parms.

### DIFF
--- a/ea_airflow_util/__init__.py
+++ b/ea_airflow_util/__init__.py
@@ -7,6 +7,7 @@ from ea_airflow_util.dags.update_dbt_docs_dag import UpdateDbtDocsDag
 from ea_airflow_util.dags.s3_to_snowflake_dag import S3ToSnowflakeDag
 from ea_airflow_util.dags.dbt_snapshot_dag import DbtSnapshotDag
 from ea_airflow_util.dags.sftp_to_snowflake_dag import SFTPToSnowflakeDag
+from ea_airflow_util.dags.sharefile_custom_users_dag import LoadSharefileCustomUsersDag
 
 from ea_airflow_util.callables.airflow import xcom_pull_template
 from ea_airflow_util.callables import slack as slack_callbacks

--- a/ea_airflow_util/dags/sharefile_custom_users_dag.py
+++ b/ea_airflow_util/dags/sharefile_custom_users_dag.py
@@ -65,6 +65,7 @@ class LoadSharefileCustomUsersDag:
         self.delete_remote = delete_remote
 
         self.dag = EACustomDAG(**kwargs)
+        self.build_sharefile_custom_users_dag()
         
     def build_sharefile_custom_users_dag(self, **kwargs):
 


### PR DESCRIPTION
## Description & motivation
This PR includes two key additions:
1. Added `self.build_sharefile_custom_users_dag()` in `sharefile_custom_users_dag.py` to enable task group visualization in the Airflow UI.
2. Added from `ea_airflow_util.dags.sharefile_custom_users_dag` import `LoadSharefileCustomUsersDag` in `__init__.py` of `ea_airflow_util` to allow package import in external implementations.

## PR Merge Priority:
- [ ] Low
- [ ] Medium
- [x] High

## Tests and QC done:
- Executed a successful run of the package with these settings in dev.