### PR TITLE
fix dbt run logic that is forcing full refresh

### DIFF
--- a/ea_airflow_util/dags/run_dbt_airflow_dag.py
+++ b/ea_airflow_util/dags/run_dbt_airflow_dag.py
@@ -148,7 +148,8 @@ class RunDbtDag:
         """
         # set a logic to force a full refresh 
         day = datetime.today().weekday()
-        if self.full_refresh_schedule == day or "{{ dag_run.conf['full_refresh'] }}":
+        dag_conf_full_refresh = kwargs.get('dag_run', {}).get('conf', {}).get('full_refresh') or False
+        if self.full_refresh_schedule == day or dag_conf_full_refresh:
            self.full_refresh = True
 
         with TaskGroup(


### PR DESCRIPTION
This: `"{{ dag_run.conf['full_refresh'] }}"` always evaluates to True. I'm not sure if my code is the best/most coherent replacement, but I have tested that it does work (allows full_refresh to be truly configured to False)