### PR TITLE
Add pagination to `SharefileHook._find_items()` using a while-loop that breaks when no records are returned.

### DIFF
--- a/ea_airflow_util/callables/sharefile.py
+++ b/ea_airflow_util/callables/sharefile.py
@@ -127,7 +127,7 @@ def disk_to_sharefile(sf_conn_id: str, sf_folder_path: str, local_path: str):
     """Post a file or the contents of a directory to the specified Sharefile folder"""
     sf_hook = SharefileHook(sf_conn_id )
 
-    sf_folder_id = sf_hook.folder_id_from_path(sf_folder_path)
+    sf_folder_id = sf_hook.get_path_id(sf_folder_path)
     if sf_folder_id is None:
         raise AirflowException(f"failed to find Sharefile folder {sf_folder_path}")
 

--- a/ea_airflow_util/callables/sharefile.py
+++ b/ea_airflow_util/callables/sharefile.py
@@ -33,6 +33,7 @@ def sharefile_to_disk(
     ds_nodash: Optional[str] = None,  # Deprecated
     ts_nodash: Optional[str] = None,  # Deprecated
     delete_remote: bool = False,
+    recursive: bool = True,
     file_pattern: Optional[str] = None,
     **kwargs
 ):
@@ -55,10 +56,30 @@ def sharefile_to_disk(
     sf_hook = SharefileHook(sharefile_conn_id)
     sf_hook.get_conn()
 
-    # get the item id of the remote path, find all files within that path (up to 1000)
+    # get the item id of the remote path, find all files within that path
     try:
         base_path_id = sf_hook.get_path_id(sharefile_path)
-        remote_files = sf_hook.find_files(base_path_id)
+
+        # The default approach finds files in all subdirectories recursively.
+        if recursive:
+            remote_files = sf_hook.find_files(base_path_id)
+        
+        # `get_children` returns only top-level items, but with a different payload schema.
+        else:
+            remote_children = sf_hook.get_children(base_path_id)
+            remote_files = []
+
+            for res in remote_children:
+
+                # Folders are returned alongside items and must be filtered.
+                if res['odata.type'].endswith('Folder'):
+                    continue
+
+                res['ParentID'] = base_path_id
+                res['ParentSemanticPath'] = sharefile_path
+                res['ItemID'] = res['Id']
+                remote_files.append(res)
+
     except requests.exceptions.HTTPError as err:
         raise AirflowSkipException(
             f"{err.response.status_code} {err.response.text}: {sharefile_path}"

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -161,10 +161,10 @@ class SharefileHook(BaseHook):
         return results
 
     def find_folders(self, folder_id):
-        return self._find_items(folder_id, "Folder")
+        return list(self._find_items(folder_id, "Folder"))
 
     def find_files(self, folder_id):
-        return self._find_items(folder_id, "File")
+        return list(self._find_items(folder_id, "File"))
 
     ## this method started returning inconsistent results
     # specifically: the parentSemanticPath would sometimes be IDs rather than names

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -172,41 +172,50 @@ class SharefileHook(BaseHook):
     def _find_items(self, folder_id, item_type, unique=True):
         if not self.session:
             self.get_conn()
-        qry = {
-            "Query": {
-                "ItemType": item_type,
-                "ParentID": folder_id
-            },
-            "Paging": {
-                "Count": 1000,
-                "Skip": 0
-            },
-            "TimeoutInSeconds": 15
-        }
-
-        response = self.session.post(self.base_url + '/Items/AdvancedSimpleSearch', json=qry)
-
-        # do we need to check response.json()['TimedOut']?
-        if response.status_code != 200:
-            self.log.error('Search failed')
-            response.raise_for_status()
-
-        results = response.json()['Results']
 
         # it appears that, in the presense of file versioning, search will return
         # multiple items, though with the same ID and no mechanism to distinguish between 
         # versions via the api. Since this is useless, by default we will make the search 
         # results unique by item id.
-        if unique:
-            item_ids = set()
-            unique_items = []
-            for item in results:
-                if item['ItemID'] not in item_ids:
-                    item_ids.add(item['ItemID'])
-                    unique_items.append(item)
-            results = unique_items
+        item_ids = set()
 
-        return results
+        # Paginate until break is raised when no records are returned.
+        skip = 0
+
+        while True:
+
+            qry = {
+                "Query": {
+                    "ItemType": item_type,
+                    "ParentID": folder_id
+                },
+                "Paging": {
+                    "Count": 1000,
+                    "Skip": skip
+                },
+                "TimeoutInSeconds": 15
+            }
+
+            response = self.session.post(self.base_url + '/Items/AdvancedSimpleSearch', json=qry)
+            skip += 1000  # Increment skip for next page call
+
+            # do we need to check response.json()['TimedOut']?
+            if response.status_code != 200:
+                self.log.error('Search failed')
+                response.raise_for_status()
+
+            # End pagination if no items were retrieved.
+            if not (results := response.json()['Results']):
+                break
+
+            for item in results:
+
+                if unique and item['ItemID'] in item_ids:
+                    continue
+
+                item_ids.add(item['ItemID'])
+                yield item
+
 
     def get_access_controls(self, item_id):
         # establish a session if we don't already have one

--- a/ea_airflow_util/providers/sharefile/hooks/sharefile.py
+++ b/ea_airflow_util/providers/sharefile/hooks/sharefile.py
@@ -197,7 +197,6 @@ class SharefileHook(BaseHook):
             }
 
             response = self.session.post(self.base_url + '/Items/AdvancedSimpleSearch', json=qry)
-            skip += 1000  # Increment skip for next page call
 
             # do we need to check response.json()['TimedOut']?
             if response.status_code != 200:
@@ -207,6 +206,8 @@ class SharefileHook(BaseHook):
             # End pagination if no items were retrieved.
             if not (results := response.json()['Results']):
                 break
+
+            skip += len(results)  # Increment skip for next page call
 
             for item in results:
 


### PR DESCRIPTION
# Hotfix/ShareFile Pagination
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
This PR adds pagination to internal ShareFile hook methods that loop over files and folders. This is required now that there's over 1000 folders present in the South Carolina ShareFile instance.

Additionally, this PR adds a new `recursive` flag to the `sharefile_to_disk` callable that defaults to True. When set to False, a different API call is made to only return files in the top-level of the specified directory, instead of all nested files.
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [ ] Low
- [ ] Medium
- [x] High

<!---
If High Priority, explain why as a comment below.
-->
This is required for sending no-match student files to ShareFile during assessment loading in South Carolina.

## Changes to existing files:
- `ea_airflow_util.providers.sharefile.hooks.sharefile.py`: Overhaul internal `_find_items()` method to paginate and return items as a generator.
- `ea_airflow_util.callables.sharefile.py`:
  - Use `SharefileHook.get_path_id()` instead of `.folder_id_from_path()` in `disk_to_sharefile()` callable as a direct folder lookup to avoid needing to use pagination anyway.
  - Add recursive flag and non-recursive logic option to `sharefile_to_disk()`.
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->
All updates tested in South Carolina.

## Future ToDos & Questions:
<!---
[Optional] Include any future steps and questions related to this PR.
-->
~~The `count` argument in the code is set to 1000, but only 999 items are returned. Should the `skip` be set to 1000 or 999? Should the `count` argument be set to 1001 to actually retrieve 1000 items? Should we end pagination if less than 1000 items are retrieved, once we figure out how to get that number of results?~~
I updated the method to paginate by the number of items returned until none are retrieved, so this question is no longer relevant.