### PR TITLE
Feature: Sharefile to Snowflake DAG Class

### DIFF
--- a/ea_airflow_util/dags/s3_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/s3_to_snowflake_dag.py
@@ -36,7 +36,7 @@ class S3ToSnowflakeDag:
         is_manual_upload: bool = False,
 
         pool: str,
-        full_replace: bool = False,  #TODO once on latest version of airflow, use dagrun parameter to allow full_replace runs even if not set here at dag level
+        full_replace: bool = False, 
 
         do_delete_from_source: bool = True,
         **kwargs

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -51,6 +51,8 @@ class SharefileTransferToSnowflakeDagBuilder:
                        default_args=self.airflow_default_args, 
                        schedule_interval=self.schedule_interval
                        )
+        
+        globals()[self.dag_id] = self.dag
 
     def check_if_file_in_params(self, file):
         """

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -53,8 +53,8 @@ class SharefileTransferToSnowflakeDagBuilder:
                        schedule_interval=self.schedule_interval
                        )
         
-        self.pull_date = "{{ ds_nodash }}"
-        self.pull_timestamp = "{{ ts_nodash }}"
+        self.pull_date = datetime.now().strftime('%Y%m%d') 
+        self.pull_timestamp = datetime.now().strftime('%Y%m%dT%H%M%S') 
     
     def build_structured_path(self, base_path, file, separator="/"):
         """

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -36,9 +36,9 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.schedule_interval = schedule_interval
 
         self.dag = None
-        self._initialize_dag()
+        # self._initialize_dag()
     
-    def _initialize_dag(self):
+    def initialize_dag(self):
         """
         Initializes the DAG with the provided configuration and sets up the parameters.
 

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -149,7 +149,7 @@ class SharefileTransferToSnowflakeDagBuilder:
             dag=self.dag
         )
 
-    def transfer_disk_to_s3(self, file, local_path, base_s3_key, s3_conn_id
+    def transfer_disk_to_s3(self, file, local_path, base_s3_destination_key, s3_conn_id
                             ) -> PythonOperator:
         """
         Transfers a file from local disk to Amazon S3.
@@ -162,7 +162,7 @@ class SharefileTransferToSnowflakeDagBuilder:
         Returns:
             PythonOperator: The Airflow task to transfer the file from local disk to S3.
         """
-        structured_s3_key = self.build_structured_path(base_s3_key, file, separator="/")
+        structured_s3_key = self.build_structured_path(base_s3_destination_key, file, separator="/")
 
         return PythonOperator(
             task_id=f"transfer_{file}_to_s3",
@@ -176,7 +176,7 @@ class SharefileTransferToSnowflakeDagBuilder:
         )
 
     def transfer_s3_to_snowflake(self, file, snowflake_conn_id, database, 
-                                 schema, s3_destination_key, full_refresh):
+                                 schema, base_s3_destination_key, full_refresh):
         """
         Transfers a file from Amazon S3 to Snowflake.
 
@@ -196,7 +196,7 @@ class SharefileTransferToSnowflakeDagBuilder:
             database=database,
             schema=schema,
             table_name=file,
-            s3_destination_key=s3_destination_key,
+            s3_destination_key=base_s3_destination_key,
             full_refresh=full_refresh,
             dag=self.dag
         )

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -11,6 +11,7 @@ from edu_edfi_airflow.callables import s3
 from ea_airflow_util.providers.aws.operators.s3 import S3ToSnowflakeOperator
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from ea_airflow_util import EACustomDAG
 
 
 class SharefileTransferToSnowflakeDagBuilder:
@@ -27,13 +28,13 @@ class SharefileTransferToSnowflakeDagBuilder:
 
     def __init__(self,
                 dag_id,
-                airflow_default_args, 
-                file_sources, 
+                airflow_default_args_dict, 
+                file_sources_dict, 
                 schedule_interval = None
     ):
         self.dag_id = dag_id
-        self.airflow_default_args = airflow_default_args
-        self.file_sources = file_sources
+        self.airflow_default_args = airflow_default_args_dict
+        self.file_sources = file_sources_dict
         self.schedule_interval = schedule_interval
 
         self.params_dict = {
@@ -45,8 +46,8 @@ class SharefileTransferToSnowflakeDagBuilder:
             ),
         }
 
-        self.dag = DAG(dag_id=self.dag_id, 
-                       params=self.params_dict,
+        self.dag = EACustomDAG(dag_id=self.dag_id, 
+                        params=self.params_dict,
                        default_args=self.airflow_default_args, 
                        schedule_interval=self.schedule_interval
                        )

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -1,5 +1,6 @@
-import os
 from datetime import datetime
+import logging
+import os
 
 from airflow import DAG
 from airflow.models import Param
@@ -15,6 +16,10 @@ from ea_airflow_util.callables.airflow import xcom_pull_template
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from ea_airflow_util import EACustomDAG
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 
 class SharefileTransferToSnowflakeDagBuilder:
     """
@@ -27,29 +32,22 @@ class SharefileTransferToSnowflakeDagBuilder:
         file_sources (list): List of file sources to be processed.
         schedule_interval (str or None): The schedule interval for the DAG.
     """
-
     def __init__(self,
                 dag_id: str,
                 airflow_default_args: dict,
                 file_sources: dict,
-                schedule_interval = None,
-
                 local_base_path: str,
-                transform_csv_to_jsonl: bool = False, 
-
-                # sharefile_path: str,
                 sharefile_conn_id: str,
-                delete_remote: bool = False,
-                
-                delete_local_csv: bool = False,
-
                 base_s3_destination_key: str,
                 s3_conn_id: str,
-
                 snowflake_conn_id: str,
                 database: str,
                 schema: str,
                 full_refresh: bool,
+                schedule_interval = None,
+                transform_csv_to_jsonl: bool = False, 
+                delete_remote: bool = False,
+                delete_local_csv: bool = False
                 ):
         self.dag_id = dag_id
         self.airflow_default_args = airflow_default_args
@@ -59,7 +57,6 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.local_base_path = local_base_path
         self.transform_csv_to_jsonl = transform_csv_to_jsonl
 
-        # self.sharefile_path = sharefile_path
         self.sharefile_conn_id = sharefile_conn_id
         self.delete_remote = delete_remote
         
@@ -72,6 +69,8 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.database = database
         self.schema = schema
         self.full_refresh = full_refresh
+
+        self.logger = logging.getLogger(self.__class__.__name__)
 
         self.params_dict = {
             "file_sources": Param(

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -52,10 +52,13 @@ class SharefileTransferToSnowflakeDagBuilder:
                        default_args=self.airflow_default_args, 
                        schedule_interval=self.schedule_interval
                        )
+        
+        self.pull_date = datetime.now().strftime('%Y%m%d') 
+        self.pull_timestamp = datetime.now().strftime('%Y%m%dT%H%M%S') 
     
     def build_structured_path(self, base_path, file, separator="/"):
         """
-        Constructs a structured path using the current date and time.
+        Constructs a structured path using the current date and timestamp.
 
         Args:
             base_path (str): The root directory or base key where files should be stored.
@@ -68,11 +71,10 @@ class SharefileTransferToSnowflakeDagBuilder:
             str: The fully structured path where the file will be stored.
         """
         # Get the execution date and time
-        execution_date = datetime.now().strftime('%Y%m%d') 
-        execution_time = datetime.now().strftime('%H%M%S') 
+
         
         # Construct the full path (e.g., "/tmp/sharefile/20250312/143500/file.csv" OR "s3://bucket/key/20250312/143500/file.csv")
-        structured_path = f"{base_path}{separator}{execution_date}{separator}{execution_time}{separator}{file}"
+        structured_path = f"{base_path}{separator}{self.pull_date}{separator}{self.pull_timestamp}{separator}{file}"
         
         return structured_path
 

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -55,27 +55,6 @@ class SharefileTransferToSnowflakeDagBuilder:
         
         self.pull_date = datetime.now().strftime('%Y%m%d') 
         self.pull_timestamp = datetime.now().strftime('%Y%m%dT%H%M%S') 
-    
-    def build_structured_path(self, base_path, file, separator="/"):
-        """
-        Constructs a structured path using the current date and timestamp.
-
-        Args:
-            base_path (str): The root directory or base key where files should be stored.
-            file (str): The filename.
-            separator (str, optional): The separator to use for the path. Defaults to '/' for directories
-                                       and can be set to an appropriate separator for other storage systems
-                                       (e.g., AWS S3 uses '/').
-        
-        Returns:
-            str: The fully structured path where the file will be stored.
-        """
-
-        
-        # Construct the full path (e.g., "/tmp/sharefile/20250312/143500/file.csv" OR "s3://bucket/key/20250312/143500/file.csv")
-        structured_path = f"{base_path}{separator}{'ds_nodash'}{separator}{'ts_nodash'}{separator}{file}"
-        
-        return structured_path
 
     def check_if_file_in_params(self, file):
         """
@@ -202,3 +181,5 @@ class SharefileTransferToSnowflakeDagBuilder:
             full_refresh=full_refresh,
             dag=self.dag
         )
+    
+    

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -16,7 +16,16 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
 class SharefileTransferToSnowflakeDagBuilder:
     """
-    ::
+    This class is responsible for creating an Apache Airflow DAG that automates the process of transferring
+    files from ShareFile to Snowflake. It defines the steps to handle file transfers, transformations, and
+    data loading operations. The DAG is dynamically built based on provided parameters such as file sources
+    and schedule interval. Each method in this class corresponds to a specific step in the workflow.
+
+    Attributes:
+        dag_id (str): The ID for the Airflow DAG.
+        airflow_default_args (dict): Default arguments passed to the DAG.
+        file_sources (list): List of file sources to be processed.
+        schedule_interval (str or None): The schedule interval for the DAG.
     """
     def __init__(self,
                 dag_id,
@@ -33,6 +42,15 @@ class SharefileTransferToSnowflakeDagBuilder:
         self._initialize_dag()
     
     def _initialize_dag(self):
+        """
+        Initializes the DAG with the provided configuration and sets up the parameters.
+
+        This method creates a DAG object and configures its parameters, including the list of file sources.
+        The file sources are passed as an Airflow parameter, allowing the workflow to be flexible in handling 
+        multiple sources.
+
+        This is an internal method used to initialize the DAG.
+        """
         params = {
             "file_sources": Param(
                 default=list(self.file_sources, {}),
@@ -51,7 +69,18 @@ class SharefileTransferToSnowflakeDagBuilder:
         )
 
     def check_if_file_in_params(self, file):
-        """Checks if the file exists in the provided parameters."""
+        """
+        Checks if the specified file exists in the provided Airflow parameters list.
+
+        This method creates a PythonOperator task that calls a custom function `skip_if_not_in_params_list` 
+        to check if the given file exists in the parameters defined in the DAG.
+
+        Args:
+            file (str): The name of the file to check in the parameters.
+
+        Returns:
+            PythonOperator: The Airflow task that checks if the file is in the parameters list.
+        """
         return PythonOperator(
             task_id=f"check_{file}",
             python_callable=skip_if_not_in_params_list,
@@ -64,7 +93,23 @@ class SharefileTransferToSnowflakeDagBuilder:
 
     def transfer_sharefile_to_disk(self, file, sharefile_conn_id, 
                                     sharefile_path, local_path, delete_remote):
-        """Transfers file from ShareFile to local disk."""
+        """
+        Transfers a file from ShareFile to a local disk.
+
+        This method creates a SharefileToDiskOperator task that handles the actual transfer of a file from 
+        ShareFile to a specified local disk location. The file is downloaded from ShareFile and saved 
+        locally, and the option to delete the remote file after transfer is provided.
+
+        Args:
+            file (str): The name of the file to transfer.
+            sharefile_conn_id (str): The Airflow connection ID for ShareFile.
+            sharefile_path (str): The file path in ShareFile from where the file will be fetched.
+            local_path (str): The local directory path where the file will be saved.
+            delete_remote (bool): Flag indicating whether to delete the remote file after transfer.
+
+        Returns:
+            SharefileToDiskOperator: The Airflow task to transfer the file from ShareFile to local disk.
+        """
         return SharefileToDiskOperator(
             task_id=f"transfer_{file}_to_disk",
             sharefile_conn_id=sharefile_conn_id,
@@ -75,7 +120,21 @@ class SharefileTransferToSnowflakeDagBuilder:
         )
 
     def transform_to_jsonl(self, file, local_path, delete_csv):
-        """Transforms CSV to JSONL."""
+        """
+        Transforms a CSV file to JSONL format.
+
+        This method creates a PythonOperator task to invoke a transformation function that converts a CSV 
+        file into JSONL format. The option to delete the original CSV file after transformation is also 
+        supported.
+
+        Args:
+            file (str): The name of the file to transform.
+            local_path (str): The local file path of the CSV file to be transformed.
+            delete_csv (bool): Flag indicating whether to delete the CSV file after transformation.
+
+        Returns:
+            PythonOperator: The Airflow task that transforms the CSV to JSONL.
+        """
         return PythonOperator(
             task_id=f"transform_{file}_to_jsonl",
             python_callable=jsonl.translate_csv_file_to_jsonl,
@@ -89,7 +148,18 @@ class SharefileTransferToSnowflakeDagBuilder:
         )
 
     def transfer_disk_to_s3(self, file):
-        """Transfers file from local disk to S3."""
+        """
+        Transfers a file from local disk to Amazon S3.
+
+        This method creates a PythonOperator task that uploads a file from the local disk to an S3 bucket. 
+        The file will be stored in a specific location defined by the S3 destination key.
+
+        Args:
+            file (str): The name of the file to transfer.
+
+        Returns:
+            PythonOperator: The Airflow task to transfer the file from local disk to S3.
+        """
         return PythonOperator(
             task_id=f"transfer_{file}_to_s3",
             python_callable=s3.local_filepath_to_s3,
@@ -103,7 +173,22 @@ class SharefileTransferToSnowflakeDagBuilder:
 
     def transfer_s3_to_snowflake(self, file, snowflake_conn_id, database, schema,
                                  full_refresh):
-        """Transfers file from S3 to Snowflake."""
+        """
+        Transfers a file from Amazon S3 to Snowflake.
+
+        This method creates an S3ToSnowflakeOperator task that loads a file from S3 into a Snowflake table.
+        It supports full refresh functionality, which replaces the existing data with the new data.
+
+        Args:
+            file (str): The name of the file to transfer.
+            snowflake_conn_id (str): The Airflow connection ID for Snowflake.
+            database (str): The Snowflake database where the data will be loaded.
+            schema (str): The Snowflake schema where the data will be loaded.
+            full_refresh (bool): Flag to determine whether to perform a full refresh of the data.
+
+        Returns:
+            S3ToSnowflakeOperator: The Airflow task to transfer the file from S3 to Snowflake.
+        """
         return S3ToSnowflakeOperator(
             task_id=f"{file}_s3_to_snowflake",
             snowflake_conn_id=snowflake_conn_id,

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -25,15 +25,6 @@ class SharefileTransferToSnowflakeDagBuilder:
         schedule_interval (str or None): The schedule interval for the DAG.
     """
 
-    params_dict = {
-        "file_sources": Param(
-            default=list(self.file_sources),
-            examples=list(self.file_sources),
-            type="list",
-            description="Newline-separated list of file sources to pull from ShareFile",
-        ),
-    }
-        
     def __init__(self,
                 dag_id,
                 airflow_default_args, 
@@ -46,7 +37,20 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.file_sources = file_sources
         self.schedule_interval = schedule_interval
 
-        self.dag = Dag(params=self.params_dict, **kwargs)
+        self.params_dict = {
+            "file_sources": Param(
+                default=list(self.file_sources),
+                examples=list(self.file_sources),
+                type="list",
+                description="Newline-separated list of file sources to pull from ShareFile",
+            ),
+        }
+
+        self.dag = DAG(dag_id=self.dag_id, 
+                       params=self.params_dict,
+                       default_args=self.airflow_default_args, 
+                       schedule_interval=self.schedule_interval, 
+                       **kwargs)
 
     def check_if_file_in_params(self, file):
         """

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -29,8 +29,7 @@ class SharefileTransferToSnowflakeDagBuilder:
                 dag_id,
                 airflow_default_args, 
                 file_sources, 
-                schedule_interval = None, 
-                **kwargs
+                schedule_interval = None
     ):
         self.dag_id = dag_id
         self.airflow_default_args = airflow_default_args
@@ -49,8 +48,8 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.dag = DAG(dag_id=self.dag_id, 
                        params=self.params_dict,
                        default_args=self.airflow_default_args, 
-                       schedule_interval=self.schedule_interval, 
-                       **kwargs)
+                       schedule_interval=self.schedule_interval
+                       )
 
     def check_if_file_in_params(self, file):
         """

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -16,32 +16,18 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
 class SharefileTransferToSnowflakeDagBuilder:
     """
-    :param configs_dir:
-    :param airflow_config:
-    :param sharefile_sources:
-    :param sharefile_conn_id:
-    :param s3_destination_key:
-    :param s3_conn_id:
-    :param snowflake_conn_id:
-    :: 
+    ::
     """
-    def __init__(self, 
-                 configs_dir: str, 
-                 airflow_config: str, 
-                 sharefile_sources: str,
-                 sharefile_conn_id: str,
-                 s3_destination_key: str,
-                 s3_conn_id: str,
-                 snowflake_conn_id: str
+    def __init__(self,
+                dag_id,
+                airflow_default_args, 
+                file_sources, 
+                schedule_interval = None
     ):
-        self.configs_dir = configs_dir
-        self.airflow_config = airflow_config
-        self.dag_configs = self.airflow_configs['sharefile_transfer_pred']
-        self.file_sources_dict = io_helpers.safe_load_yaml(configs_dir, sharefile_sources)
-        self.sharefile_conn_id = sharefile_conn_id
-        self.s3_destination_key = s3_destination_key
-        self.s3_conn_id = s3_conn_id
-        self.snowflake_conn_id = snowflake_conn_id
+        self.dag_id = dag_id
+        self.airflow_default_args = airflow_default_args
+        self.file_sources = file_sources
+        self.schedule_interval = schedule_interval
 
         self.dag = None
         self._initialize_dag()
@@ -49,19 +35,18 @@ class SharefileTransferToSnowflakeDagBuilder:
     def _initialize_dag(self):
         params = {
             "file_sources": Param(
-                default=list(self.file_sources_dict.get(self.run_type, {})),
-                examples=list(self.file_sources_dict.get(self.run_type, {})),
-                type="array",
-                description="Newline-separated list of file sources to pull from ShareFile (default all in `sharefile_sources.yml`)",
+                default=list(self.file_sources, {}),
+                examples=list(self.file_sources, {}),
+                type="list",
+                description="Newline-separated list of file sources to pull from ShareFile",
             ),
         }
 
         self.dag = DAG(
-            dag_id=f"sharefile_{self.run_type}_transfer",
-            default_args=self.dag_configs['default_args'],
-            schedule_interval=self.dag_configs['schedule_interval'],
+            dag_id=self.dag_id,
+            default_args=self.airflow_default_args,
+            schedule_interval=self.schedule_interval,
             params=params,
-            user_defined_macros={'slack_conn_id': None},
             catchup=False,
         )
 
@@ -77,56 +62,58 @@ class SharefileTransferToSnowflakeDagBuilder:
             dag=self.dag
         )
 
-    # def transfer_sharefile_to_disk(self, file, file_configs):
-    #     """Transfers file from ShareFile to local disk."""
-    #     return SharefileToDiskOperator(
-    #         task_id=f"transfer_{file}_to_disk",
-    #         sharefile_conn_id=self.dag_configs['sharefile_conn_id'],
-    #         sharefile_path=file_configs['sharefile_path'],
-    #         local_path=self._generate_file_path(file, 'disk'),
-    #         delete_remote=self.dag_configs['delete_remote'],
-    #         dag=self.dag
-    #     )
+    def transfer_sharefile_to_disk(self, file, sharefile_conn_id, 
+                                    sharefile_path, local_path, delete_remote):
+        """Transfers file from ShareFile to local disk."""
+        return SharefileToDiskOperator(
+            task_id=f"transfer_{file}_to_disk",
+            sharefile_conn_id=sharefile_conn_id,
+            sharefile_path=sharefile_path,
+            local_path=local_path,
+            delete_remote=delete_remote,
+            dag=self.dag
+        )
 
-    # def transform_to_jsonl(self, transfer_task, file):
-    #     """Transforms CSV to JSONL."""
-    #     return PythonOperator(
-    #         task_id=f"transform_{file}_to_jsonl",
-    #         python_callable=jsonl.translate_csv_file_to_jsonl,
-    #         op_kwargs={
-    #             'local_path': xcom_pull_template(transfer_task),
-    #             'output_path': None,
-    #             'delete_csv': True,
-    #             'metadata_dict': {'file_source': file},
-    #         },
-    #         dag=self.dag
-    #     )
+    def transform_to_jsonl(self, file, local_path, delete_csv):
+        """Transforms CSV to JSONL."""
+        return PythonOperator(
+            task_id=f"transform_{file}_to_jsonl",
+            python_callable=jsonl.translate_csv_file_to_jsonl,
+            op_kwargs={
+                'local_path': local_path,
+                'output_path': None,
+                'delete_csv': delete_csv,
+                'metadata_dict': {'file_source': file},
+            },
+            dag=self.dag
+        )
 
-    # def _transfer_disk_to_s3(self, file):
-    #     """Transfers file from local disk to S3."""
-    #     return PythonOperator(
-    #         task_id=f"transfer_{file}_to_s3",
-    #         python_callable=s3.local_filepath_to_s3,
-    #         op_kwargs={
-    #             'local_filepath': self._generate_file_path(file, 'disk'),
-    #             's3_destination_key': f"ea_research/{file}",
-    #             's3_conn_id': self.dag_configs['s3_conn_id']
-    #         },
-    #         dag=self.dag
-    #     )
+    def transfer_disk_to_s3(self, file):
+        """Transfers file from local disk to S3."""
+        return PythonOperator(
+            task_id=f"transfer_{file}_to_s3",
+            python_callable=s3.local_filepath_to_s3,
+            op_kwargs={
+                'local_filepath': self._generate_file_path(file, 'disk'),
+                's3_destination_key': f"ea_research/{file}",
+                's3_conn_id': self.dag_configs['s3_conn_id']
+            },
+            dag=self.dag
+        )
 
-    # def transfer_s3_to_snowflake(self, file):
-    #     """Transfers file from S3 to Snowflake."""
-    #     return S3ToSnowflakeOperator(
-    #         task_id=f"{file}_s3_to_snowflake",
-    #         snowflake_conn_id=self.dag_configs['snowflake_conn_id'],
-    #         database=self.dag_configs['snowflake_db'],
-    #         schema=self.dag_configs['snowflake_schema'],
-    #         table_name=file,
-    #         s3_destination_key=f"ea_research/{file}",
-    #         full_refresh=True,
-    #         dag=self.dag
-    #     )
+    def transfer_s3_to_snowflake(self, file, snowflake_conn_id, database, schema,
+                                 full_refresh):
+        """Transfers file from S3 to Snowflake."""
+        return S3ToSnowflakeOperator(
+            task_id=f"{file}_s3_to_snowflake",
+            snowflake_conn_id=snowflake_conn_id,
+            database=database,
+            schema=schema,
+            table_name=file,
+            s3_destination_key=f"ea_research/{file}",
+            full_refresh=full_refresh,
+            dag=self.dag
+        )
 
     # def build_dag(self):
     #     """Builds the complete DAG, setting up tasks and their dependencies."""

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -68,8 +68,8 @@ class SharefileTransferToSnowflakeDagBuilder:
             str: The fully structured path where the file will be stored.
         """
         # Get the execution date and time
-        execution_date = datetime.now().strftime('%Y%m%d')  # e.g., 20250312
-        execution_time = datetime.now().strftime('%H%M%S')  # e.g., 143500
+        execution_date = datetime.now().strftime('%Y%m%d') 
+        execution_time = datetime.now().strftime('%H%M%S') 
         
         # Construct the full path (e.g., "/tmp/sharefile/20250312/143500/file.csv" OR "s3://bucket/key/20250312/143500/file.csv")
         structured_path = f"{base_path}{separator}{execution_date}{separator}{execution_time}{separator}{file}"
@@ -97,7 +97,7 @@ class SharefileTransferToSnowflakeDagBuilder:
         )
 
     def transfer_sharefile_to_disk(self, file, sharefile_conn_id, 
-                                    sharefile_path, base_path, delete_remote):
+                                    sharefile_path, local_base_path, delete_remote):
         """
         Transfers a file from ShareFile to a local disk.
 
@@ -111,7 +111,7 @@ class SharefileTransferToSnowflakeDagBuilder:
         Returns:
             SharefileToDiskOperator: The Airflow task to transfer the file from ShareFile to local disk.
         """
-        structured_local_path = self.build_structured_path(base_path, file)
+        structured_local_path = self.build_structured_path(local_base_path, file)
 
         os.makedirs(os.path.dirname(structured_local_path), exist_ok=True)
 

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -41,7 +41,7 @@ class SharefileTransferToSnowflakeDagBuilder:
             "file_sources": Param(
                 default=list(self.file_sources.keys()),
                 examples=list(self.file_sources.keys()),
-                type="list",
+                type="array",
                 description="Newline-separated list of file sources to pull from ShareFile",
             ),
         }

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -1,0 +1,153 @@
+import os
+
+from airflow import DAG
+from airflow.models import Param
+from airflow.operators.python import PythonOperator
+
+from util import io_helpers
+
+from ea_airflow_util.callables.airflow import skip_if_not_in_params_list, xcom_pull_template
+from ea_airflow_util.callables import jsonl, snowflake
+from ea_airflow_util.providers.sharefile.transfers.sharefile_to_disk import SharefileToDiskOperator
+from edu_edfi_airflow.callables import s3
+from ea_airflow_util.providers.aws.operators.s3 import S3ToSnowflakeOperator
+
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+class SharefileTransferToSnowflakeDagBuilder:
+    """
+    :param configs_dir:
+    :param airflow_config:
+    :param sharefile_sources:
+    :param sharefile_conn_id:
+    :param s3_destination_key:
+    :param s3_conn_id:
+    :param snowflake_conn_id:
+    :: 
+    """
+    def __init__(self, 
+                 configs_dir: str, 
+                 airflow_config: str, 
+                 sharefile_sources: str,
+                 sharefile_conn_id: str,
+                 s3_destination_key: str,
+                 s3_conn_id: str,
+                 snowflake_conn_id: str
+    ):
+        self.configs_dir = configs_dir
+        self.airflow_config = airflow_config
+        self.dag_configs = self.airflow_configs['sharefile_transfer_pred']
+        self.file_sources_dict = io_helpers.safe_load_yaml(configs_dir, sharefile_sources)
+        self.sharefile_conn_id = sharefile_conn_id
+        self.s3_destination_key = s3_destination_key
+        self.s3_conn_id = s3_conn_id
+        self.snowflake_conn_id = snowflake_conn_id
+
+        self.dag = None
+        self._initialize_dag()
+    
+    def _initialize_dag(self):
+        params = {
+            "file_sources": Param(
+                default=list(self.file_sources_dict.get(self.run_type, {})),
+                examples=list(self.file_sources_dict.get(self.run_type, {})),
+                type="array",
+                description="Newline-separated list of file sources to pull from ShareFile (default all in `sharefile_sources.yml`)",
+            ),
+        }
+
+        self.dag = DAG(
+            dag_id=f"sharefile_{self.run_type}_transfer",
+            default_args=self.dag_configs['default_args'],
+            schedule_interval=self.dag_configs['schedule_interval'],
+            params=params,
+            user_defined_macros={'slack_conn_id': None},
+            catchup=False,
+        )
+
+    def check_if_file_in_params(self, file):
+        """Checks if the file exists in the provided parameters."""
+        return PythonOperator(
+            task_id=f"check_{file}",
+            python_callable=skip_if_not_in_params_list,
+            op_kwargs={
+                'param_name': "file_sources", 
+                'value': file
+                },
+            dag=self.dag
+        )
+
+    # def transfer_sharefile_to_disk(self, file, file_configs):
+    #     """Transfers file from ShareFile to local disk."""
+    #     return SharefileToDiskOperator(
+    #         task_id=f"transfer_{file}_to_disk",
+    #         sharefile_conn_id=self.dag_configs['sharefile_conn_id'],
+    #         sharefile_path=file_configs['sharefile_path'],
+    #         local_path=self._generate_file_path(file, 'disk'),
+    #         delete_remote=self.dag_configs['delete_remote'],
+    #         dag=self.dag
+    #     )
+
+    # def transform_to_jsonl(self, transfer_task, file):
+    #     """Transforms CSV to JSONL."""
+    #     return PythonOperator(
+    #         task_id=f"transform_{file}_to_jsonl",
+    #         python_callable=jsonl.translate_csv_file_to_jsonl,
+    #         op_kwargs={
+    #             'local_path': xcom_pull_template(transfer_task),
+    #             'output_path': None,
+    #             'delete_csv': True,
+    #             'metadata_dict': {'file_source': file},
+    #         },
+    #         dag=self.dag
+    #     )
+
+    # def _transfer_disk_to_s3(self, file):
+    #     """Transfers file from local disk to S3."""
+    #     return PythonOperator(
+    #         task_id=f"transfer_{file}_to_s3",
+    #         python_callable=s3.local_filepath_to_s3,
+    #         op_kwargs={
+    #             'local_filepath': self._generate_file_path(file, 'disk'),
+    #             's3_destination_key': f"ea_research/{file}",
+    #             's3_conn_id': self.dag_configs['s3_conn_id']
+    #         },
+    #         dag=self.dag
+    #     )
+
+    # def transfer_s3_to_snowflake(self, file):
+    #     """Transfers file from S3 to Snowflake."""
+    #     return S3ToSnowflakeOperator(
+    #         task_id=f"{file}_s3_to_snowflake",
+    #         snowflake_conn_id=self.dag_configs['snowflake_conn_id'],
+    #         database=self.dag_configs['snowflake_db'],
+    #         schema=self.dag_configs['snowflake_schema'],
+    #         table_name=file,
+    #         s3_destination_key=f"ea_research/{file}",
+    #         full_refresh=True,
+    #         dag=self.dag
+    #     )
+
+    # def build_dag(self):
+    #     """Builds the complete DAG, setting up tasks and their dependencies."""
+    #     for file, file_configs in self.file_sources_dict.get(self.run_type, {}).items():
+    #         # Task for checking if file is in parameters list
+    #         check_task = self._check_if_file_in_params(file)
+            
+    #         # Task for transferring from ShareFile to Disk
+    #         transfer_task = self._transfer_sharefile_to_disk(file, file_configs)
+            
+    #         # Task for transforming from CSV to JSONL
+    #         transform_task = self._transform_to_jsonl(transfer_task, file)
+            
+    #         # Task for transferring from Disk to S3
+    #         transfer_to_s3_task = self._transfer_disk_to_s3(file)
+            
+    #         # Task for transferring from S3 to Snowflake
+    #         s3_to_snowflake_task = self._transfer_s3_to_snowflake(file)
+
+    #         # Set task dependencies in a linear flow
+    #         check_task >> transfer_task >> transform_task >> transfer_to_s3_task >> s3_to_snowflake_task
+
+    #     return self.dag
+

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -53,8 +53,8 @@ class SharefileTransferToSnowflakeDagBuilder:
                        schedule_interval=self.schedule_interval
                        )
         
-        self.pull_date = datetime.now().strftime('%Y%m%d') 
-        self.pull_timestamp = datetime.now().strftime('%Y%m%dT%H%M%S') 
+        self.pull_date = "{{ ds_nodash }}"
+        self.pull_timestamp = "{{ ts_nodash }}"
     
     def build_structured_path(self, base_path, file, separator="/"):
         """
@@ -70,7 +70,6 @@ class SharefileTransferToSnowflakeDagBuilder:
         Returns:
             str: The fully structured path where the file will be stored.
         """
-        # Get the execution date and time
 
         
         # Construct the full path (e.g., "/tmp/sharefile/20250312/143500/file.csv" OR "s3://bucket/key/20250312/143500/file.csv")

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -38,8 +38,8 @@ class SharefileTransferToSnowflakeDagBuilder:
 
         self.params_dict = {
             "file_sources": Param(
-                default=list(self.file_sources),
-                examples=list(self.file_sources),
+                default=list(self.file_sources.keys()),
+                examples=list(self.file_sources.keys()),
                 type="list",
                 description="Newline-separated list of file sources to pull from ShareFile",
             ),

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -51,8 +51,6 @@ class SharefileTransferToSnowflakeDagBuilder:
                        default_args=self.airflow_default_args, 
                        schedule_interval=self.schedule_interval
                        )
-        
-        globals()[self.dag_id] = self.dag
 
     def check_if_file_in_params(self, file):
         """

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -36,9 +36,9 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.schedule_interval = schedule_interval
 
         self.dag = None
-        # self._initialize_dag()
+        self._initialize_dag()
     
-    def initialize_dag(self):
+    def _initialize_dag(self):
         """
         Initializes the DAG with the provided configuration and sets up the parameters.
 
@@ -60,6 +60,8 @@ class SharefileTransferToSnowflakeDagBuilder:
             params=params,
             catchup=False,
         )
+
+        globals()[self.dag.dag_id] = self.dag
 
     def check_if_file_in_params(self, file):
         """

--- a/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
+++ b/ea_airflow_util/dags/sharefile_to_snowflake_dag_builder.py
@@ -37,7 +37,7 @@ class SharefileTransferToSnowflakeDagBuilder:
                 local_base_path: str,
                 transform_csv_to_jsonl: bool = False, 
 
-                sharefile_path: str,
+                # sharefile_path: str,
                 sharefile_conn_id: str,
                 delete_remote: bool = False,
                 
@@ -50,8 +50,7 @@ class SharefileTransferToSnowflakeDagBuilder:
                 database: str,
                 schema: str,
                 full_refresh: bool,
-
-    ):
+                ):
         self.dag_id = dag_id
         self.airflow_default_args = airflow_default_args
         self.file_sources = file_sources
@@ -60,7 +59,7 @@ class SharefileTransferToSnowflakeDagBuilder:
         self.local_base_path = local_base_path
         self.transform_csv_to_jsonl = transform_csv_to_jsonl
 
-        self.sharefile_path = sharefile_path
+        # self.sharefile_path = sharefile_path
         self.sharefile_conn_id = sharefile_conn_id
         self.delete_remote = delete_remote
         
@@ -80,8 +79,8 @@ class SharefileTransferToSnowflakeDagBuilder:
                 examples=list(self.file_sources.keys()),
                 type="array",
                 description="Newline-separated list of file sources to pull from ShareFile",
-            ),
-        }
+                ),
+                }
 
         self.dag = EACustomDAG(dag_id=self.dag_id, 
                                default_args=self.airflow_default_args, 
@@ -92,7 +91,7 @@ class SharefileTransferToSnowflakeDagBuilder:
 
     def build_sharefile_to_snowflake_dag(self, **kwargs):
 
-        for file in self.file_sources.keys():
+        for file, details in self.file_sources.items():
 
             check_if_file_in_param = PythonOperator(
                 task_id=f"check_{file}",
@@ -107,7 +106,7 @@ class SharefileTransferToSnowflakeDagBuilder:
             transfer_sharefile_to_disk = SharefileToDiskOperator(
                 task_id=f"transfer_{file}_to_disk",
                 sharefile_conn_id=self.sharefile_conn_id,
-                sharefile_path=self.sharefile_path,
+                sharefile_path=details['sharefile_path'],
                 local_path=os.path.join(self.local_base_path, '{{ds_nodash}}', '{{ts_nodash}}', file),
                 delete_remote=self.delete_remote,
                 dag=self.dag

--- a/ea_airflow_util/providers/aws/operators/s3.py
+++ b/ea_airflow_util/providers/aws/operators/s3.py
@@ -186,7 +186,7 @@ class S3ToSnowflakeOperator(BaseOperator):
                     TO_TIMESTAMP(REGEXP_SUBSTR(metadata$filename, '{ts_regex}'), 'YYYYMMDDTHH24MISS') AS pull_timestamp,
                     metadata$file_row_number AS file_row_number,
                     metadata$filename AS filename,
-                    {metadata_columns}
+                    {metadata_columns if metadata_columns else ''}
                     t.$1 AS v
                 FROM @{self.database}.util.airflow_stage/{self.s3_destination_key}
                 (file_format => 'json_default') t


### PR DESCRIPTION
## Feature: Sharefile to Snowflake DAG Class


## Description & motivation:
<em>
</br>
This PR introduces a reusable Airflow DAG class designed to facilitate the ingestion of JSONL and CSV files from ShareFile into Snowflake. The process follows these steps:

1. Retrieve files from ShareFile.
2. Save them to local disk.
3. Convert CSV files to JSONL format (if applicable).
4. Upload the transformed files to a specified S3 bucket.
5. Load the files into Snowflake.

Initially developed for the [edu_ext_rally](https://github.com/edanalytics/edu_ext_rally) repository, this class was later identified as a broadly useful utility for teams needing a straightforward ShareFile-to-Snowflake ingestion DAG for CSV or JSONL files.

</em>

## PR Merge Priority:
Low: A week or more.</br>
Medium: Within 3 days or less.</br>
High: As soon as possible.</br></em>
- [x] Low </br>
- [ ] Medium </br>
- [ ] High </br>

## Tests and QC done:
<em>

- Successfully tested on the stadium_txexchange Airflow development server.
- A test DAG is available in the stadium_txexchange repository under: airflow/dags/TEST_sharefile_to_snowflake_class.py.

</em>