### PR TITLE
updated column_names_str and metadata_columns default value when dict…

### DIFF
--- a/ea_airflow_util/providers/aws/operators/s3.py
+++ b/ea_airflow_util/providers/aws/operators/s3.py
@@ -164,8 +164,8 @@ class S3ToSnowflakeOperator(BaseOperator):
                 for alias, value in self.custom_metadata_columns.items()
             ) + ","
         else:
-            column_names_str = None
-            metadata_columns = None
+            column_names_str = ""
+            metadata_columns = ""
 
         ### Build the SQL queries to be passed into `Hook.run()`.
         qry_delete = f"""


### PR DESCRIPTION
## bugfix/S3ToSnowflakeOperator: Fix invalid SQL column handling in metadata columns within execute method

## Description & Motivation  
This PR fixes an issue in the `S3ToSnowflakeOperator` where `column_names_str` and `metadata_columns` were set to `None` when `custom_metadata_columns` was not provided. This resulted in invalid SQL statements containing `None,` which caused execution failures.  

To resolve this, the two variables are now set to empty strings (`""`) instead of `None`.

## PR Merge Priority  
- [ ] Low  
- [x] Medium  
- [ ] High  

**This needs to be updated before the original project that I was working on will run correctly. 

## Changes to Code
- **`S3ToSnowflakeOperator` (`execute` method)**  
  - Updated:
    ```python
    column_names_str = None
    metadata_columns = None
    ```
    **to:**
    ```python
    column_names_str = ""
    metadata_columns = ""
    ```
  - This prevents invalid SQL syntax.

## Tests and QC Done  
- Successfully ran the DAG with and without `custom_metadata_columns.
- Reviewed the generated SQL statements to confirm that no `None` values are input.  
