### PR TITLE
Feature/S3 to Postgres optional column order detection 

### DIFF
--- a/ea_airflow_util/callables/sql.py
+++ b/ea_airflow_util/callables/sql.py
@@ -63,6 +63,7 @@ def s3_to_postgres(
     truncate: bool = False,
     delete_qry: Optional[str] = None,
     metadata_qry: Optional[str] = None,
+    column_detection_delimiter: Optional[str] = None,
     **context
 ):
     if column_customization is None:
@@ -84,6 +85,11 @@ def s3_to_postgres(
     if (s3_hook.get_key(key=s3_key, bucket_name=s3_bucket).get()['ContentLength']) == 0:
         print("File at this s3 key is empty.")
         raise AirflowSkipException
+
+    if column_detection_delimiter:
+        file_string = s3_hook.read_key(s3_key, s3_bucket)
+        header = file_string.split('\n')[0].split(column_detection_delimiter)
+        column_customization = ', '.join(header)
 
     if truncate and not delete_qry:
         with conn.cursor() as cur:

--- a/ea_airflow_util/callables/sql.py
+++ b/ea_airflow_util/callables/sql.py
@@ -63,7 +63,7 @@ def s3_to_postgres(
     truncate: bool = False,
     delete_qry: Optional[str] = None,
     metadata_qry: Optional[str] = None,
-    column_detection_delimiter: Optional[str] = None,
+    column_detection_delimiter: Optional[str] = None, # specify the column delimiter character to use column order detection (i.e. '\t')
     **context
 ):
     if column_customization is None:
@@ -136,7 +136,7 @@ def s3_dir_to_postgres(
     truncate: bool = False,
     delete_s3_dir: bool = False,
     metadata_qry: Optional[str] = None,
-    column_detection_delimiter: Optional[str] = None,
+    column_detection_delimiter: Optional[str] = None, # specify the column delimiter character to use column order detection (i.e. '\t')
     **context
 ):
     s3_hook = S3Hook(s3_conn_id)

--- a/ea_airflow_util/callables/sql.py
+++ b/ea_airflow_util/callables/sql.py
@@ -130,12 +130,18 @@ def s3_dir_to_postgres(
     truncate: bool = False,
     delete_s3_dir: bool = False,
     metadata_qry: Optional[str] = None,
+    column_detection_delimiter: Optional[str] = None,
     **context
 ):
     s3_hook = S3Hook(s3_conn_id)
     s3_creds = s3_hook.get_connection(s3_hook.aws_conn_id)
     s3_bucket = s3_creds.schema
     s3_keys = s3.list_s3_keys(s3_hook, s3_bucket, s3_key)
+
+    if column_detection_delimiter:
+        file_string = s3_hook.read_key(s3_keys[0], s3_bucket)
+        header = file_string.split('\n')[0].split(column_detection_delimiter)
+        column_customization = ', '.join(header)
 
     if truncate:
         conn = PostgresHook(pg_conn_id).get_conn()


### PR DESCRIPTION
## Description & motivation:
The `s3_to_postgres` and `s3_dir_to_postgres` callables currently rely on the S3 file(s) and the Postgres table to have matching column orders unless the order is specified in the `column_customization` config. This PR adds the option to set the column order by reading the header of the file in S3. It will be helpful for the upgrade of the `load_heimdall_dag`, currently the only user of this callable, to avoid errors due to column order.

I'm not convinced that I decided on the ideal implementation of this idea, with the user specifying the column delimiter to use the feature. I considered making the argument a boolean and parsing the delimiter from the `options` argument. That would be a simpler argument but would require some ugly regex, so I decided against it. 

## PR Merge Priority:
- [x] Low

## Tests and QC done:
- Created a test table in GSN with a different column order than the test file in S3 and confirmed that the table was loaded correctly
- Confirmed that excluding the new optional configuration does not affect exiting functionality