### PR TITLE
Fix slack alerting for Airflow 2.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# ea_airflow_util v0.3.7
+## Fixes
+- Fix change in interface in `SlackWebhookHook` instantiation in Slack callables.
+
+
 # ea_airflow_util v0.3.6
 ## New Features
 - Add `recursive` flag to `sharefile_to_disk()` callable (default `True`). When set to `False`, only top-level files are copied using an alternative API method.

--- a/ea_airflow_util/callables/slack.py
+++ b/ea_airflow_util/callables/slack.py
@@ -12,7 +12,7 @@ def _execute_slack_message(http_conn_id: str, message: str, **kwargs):
 
     Kwargs in init are passed to SlackWebhookOperator.
     """
-    return SlackWebhookHook(http_conn_id=http_conn_id, message=message, **kwargs).execute()
+    return SlackWebhookHook(slack_webhook_conn_id=http_conn_id, **kwargs).send(text=message)
 
 def slack_alert_failure(context: dict, http_conn_id: str, **kwargs):
     """  """

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='ea_airflow_util',
-      version='0.3.6',
+      version='0.3.7',
       description='EA Airflow tools',
       license_files=['LICENSE'],
       url='https://github.com/edanalytics/ea_airflow_util',


### PR DESCRIPTION
This PR fixes slack alerting, which in [apache-airflow-providers-slack 8.0.0 changed](https://airflow.apache.org/docs/apache-airflow-providers-slack/8.0.0/_api/airflow/providers/slack/hooks/slack_webhook/index.html#airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook) the `SlackWebhookHook.__init__()` signature, _requiring_ the `slack_webhook_conn_id` parameter, and also _removed_ the `execute()` class method (which we were using). I've tested this updated version, it seems to work with Airflow 2.9.3 (which uses apache-airflow-providers-slack 8.7.1).