### PR TITLE
New RotateAirflowLogs DAG for deleting empty log directories

### DIFF
--- a/ea_airflow_util/dags/rotate_airflow_logs.py
+++ b/ea_airflow_util/dags/rotate_airflow_logs.py
@@ -1,0 +1,56 @@
+import logging
+import os
+
+from ea_airflow_util import EACustomDAG
+
+from airflow.decorators import task
+
+
+class RotateLogsDAG:
+    """
+    A DAG for rotating Airflow logs.
+
+    Currently, this DAG only deletes empty directories in the Airflow logs
+    folder. It does not save off logs or delete logs at this time. See Jira item
+    https://edanalytics.atlassian.net/browse/STAD-198
+
+    If located somewhere other than `$AIRFLOW_HOME/logs`, set the `logs_dir`
+    parameter to the path to the Airflow logs root directory.
+
+    Example entry in an airflow_config.yml file:
+
+    ```yaml
+    rotate_logs_dag:
+        schedule_interval: "@weekly"
+        default_args: *default_task_args
+        logs_dir: /home/airflow/airflow/logs
+    ```
+    """
+
+    def __init__(self, *, logs_dir: str = None, **kwargs) -> None:
+        self.logs_dir = logs_dir or os.path.join(os.environ["AIRFLOW_HOME"], "logs")
+        self.dag = self.build_dag(**kwargs)
+
+    def get_empty_directories(self) -> list[str]:
+        empty_dirs = []
+        for root, dirs, files in os.walk(self.logs_dir):
+            # The answer to "What does it mean for a directory to be empty"
+            # could be more complex. This check works for Dag/Task directories.
+            if not dirs and not files:
+                empty_dirs.append(root)
+        return empty_dirs
+
+    def build_dag(self, **kwargs):
+        @task
+        def delete_empty_directories():
+            paths = self.get_empty_directories()
+            logging.info(f"Deleting {len(paths)} empty directories in {self.logs_dir}")
+
+            for path in paths:
+                logging.info(f"Removing empty directory {path}")
+                os.rmdir(path)
+
+        with EACustomDAG(**kwargs) as dag:
+            delete_empty_directories()
+
+        return dag

--- a/ea_airflow_util/dags/rotate_airflow_logs.py
+++ b/ea_airflow_util/dags/rotate_airflow_logs.py
@@ -10,9 +10,8 @@ class RotateLogsDAG:
     """
     A DAG for rotating Airflow logs.
 
-    Currently, this DAG only deletes empty directories in the Airflow logs
-    folder. It does not save off logs or delete logs at this time. See Jira item
-    https://edanalytics.atlassian.net/browse/STAD-198
+    Currently, this DAG only deletes empty log files and empty directories in
+    the Airflow logs folder. It does save logs or delete them.
 
     If located somewhere other than `$AIRFLOW_HOME/logs`, set the `logs_dir`
     parameter to the path to the Airflow logs root directory.
@@ -40,17 +39,40 @@ class RotateLogsDAG:
                 empty_dirs.append(root)
         return empty_dirs
 
+    def get_empty_files(self) -> list[str]:
+        empty_files = []
+        for root, _, files in os.walk(self.logs_dir):
+            for filename in files:
+                filepath = os.path.join(root, filename)
+                try:
+                    if os.path.getsize(filepath) == 0:
+                        empty_files.append(filepath)
+                except OSError:
+                    logging.warning(f"Could not access file: {filepath}")
+        return empty_files
+
     def build_dag(self, **kwargs):
         @task
-        def delete_empty_directories():
-            paths = self.get_empty_directories()
-            logging.info(f"Deleting {len(paths)} empty directories in {self.logs_dir}")
+        def delete_empty_files_and_directories():
+            # Some remote logging providers (CloudWatch) leave behind empty log
+            # files. First we delete those, then delete empty directories.
+            empty_files = self.get_empty_files()
 
-            for path in paths:
-                logging.info(f"Removing empty directory {path}")
-                os.rmdir(path)
+            logging.info(f"Deleting {len(empty_files)} empty files in {self.logs_dir}")
+            for file in empty_files:
+                logging.info(f"Removing empty file {file}")
+                os.remove(file)
+
+            # This is a loop to handle nested empty directories.
+            while empty_dirs := self.get_empty_directories():
+                logging.info(
+                    f"Deleting {len(empty_dirs)} empty directories in {self.logs_dir}"
+                )
+                for path in empty_dirs:
+                    logging.info(f"Removing empty directory {path}")
+                    os.rmdir(path)
 
         with EACustomDAG(**kwargs) as dag:
-            delete_empty_directories()
+            delete_empty_files_and_directories()
 
         return dag


### PR DESCRIPTION
Links:
* Design: [STAD-198 Add log rotation to Airflow logs](https://edanalytics.slite.com/app/docs/5PhIbfC364UvIm)
* Jira: [STAD-198 Add log rotation to Airflow logs](https://edanalytics.atlassian.net/browse/STAD-198)

Testing instructions:

In a stadium or stadium-like project, import the new DAG and instantiate it like:

```python
from ea_airflow_util import RotateLogsDAG
globals()[rotate_logs_dag.dag.dag_id] = rotate_logs_dag.dag
```

This DAG support configuration via `airflow_config.yml` under the key `rotate_logs_dag`. For example, if your logs root directory is located someplace besides `$AIRFLOW_HOME/logs`, you can configure it like:

```yaml
rotate_logs_dag:
  schedule_interval: null
  default_args: *default_task_args
  logs_dir: /some/other/airflow/logs
```

then update your instantiation code to load the config:

```python
from util import io_helpers

# Or wherever your config is:
airflow_configs_file = "/home/airflow/airflow/configs/airflow_config.yml"

AIRFLOW_CONFIGS = io_helpers.safe_load_yaml(configs_dir, airflow_configs_file)
dag_args = AIRFLOW_CONFIGS.get("rotate_logs_dag", {})

rotate_logs_dag = RotateLogsDAG(dag_id="rotate_airflow_logs", **dag_args)
globals()[rotate_logs_dag.dag.dag_id] = rotate_logs_dag.dag
```

Finally, when you run the DAG, confirm that it runs successfully, that empty sub-directories in the logging directory are deleted, and non-empty directories are not deleted. The DAG uses `os.rmdir()`, which will throw an exception if called on a non-empty directory, so there should not be a risk of deleting non-empty directories.