### PR TITLE
Feature/dbt deps

### DIFF
--- a/ea_airflow_util/dags/run_dbt_airflow_dag.py
+++ b/ea_airflow_util/dags/run_dbt_airflow_dag.py
@@ -182,7 +182,6 @@ class RunDbtDag:
                 target = self.dbt_target_name,
                 dbt_bin= self.dbt_bin_path,
                 trigger_rule='all_success',
-                full_refresh=True,
                 vars=self.deps_vars,
                 upgrade=self.deps_upgrade,
                 dag=self.dag

--- a/ea_airflow_util/dags/run_dbt_airflow_dag.py
+++ b/ea_airflow_util/dags/run_dbt_airflow_dag.py
@@ -11,7 +11,7 @@ from airflow.operators.python import PythonOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.task_group import TaskGroup
 
-from airflow_dbt.operators.dbt_operator import DbtRunOperator, DbtSeedOperator, DbtTestOperator
+from airflow_dbt.operators.dbt_operator import DbtRunOperator, DbtSeedOperator, DbtTestOperator, DbtDepsOperator
 
 from ea_airflow_util.dags.ea_custom_dag import EACustomDAG
 from ea_airflow_util.callables.variable import check_variable, update_variable
@@ -51,6 +51,7 @@ class RunDbtDag:
         full_refresh: bool = False,
         full_refresh_schedule: Optional[str] = None,
 
+        deps_vars: Optional[dict] = None,
         seed_vars: Optional[dict] = None,
         run_vars: Optional[dict] = None,
         test_vars: Optional[dict] = None,
@@ -77,6 +78,7 @@ class RunDbtDag:
         self.full_refresh_schedule = full_refresh_schedule
 
         # run-time vars
+        self.deps_vars = deps_vars
         self.seed_vars = seed_vars
         self.run_vars = run_vars
         self.test_vars = run_vars
@@ -147,8 +149,9 @@ class RunDbtDag:
     # build function for tasks
     def build_dbt_run(self, on_success_callback=None, **kwargs):
         """
-        four tasks defined here: 
+        five tasks defined here: 
 
+        dbt deps:
         dbt seed: 
         dbt run:
         dbt test:
@@ -168,6 +171,18 @@ class RunDbtDag:
             dag=self.dag
         ) as dbt_task_group:
 
+            dbt_deps = DbtDepsOperator(
+                task_id= f'dbt_deps_{self.environment}',
+                dir    = self.dbt_repo_path,
+                target = self.dbt_target_name,
+                dbt_bin= self.dbt_bin_path,
+                trigger_rule='all_success',
+                full_refresh=True,
+                vars=self.deps_vars,
+                dag=self.dag
+
+            )
+            
             dbt_seed = DbtSeedOperator(
                 task_id= f'dbt_seed_{self.environment}',
                 dir    = self.dbt_repo_path,
@@ -198,7 +213,7 @@ class RunDbtDag:
                 dag=self.dag
             )
 
-            dbt_seed >> dbt_run >> dbt_test
+            dbt_deps >> dbt_seed >> dbt_run >> dbt_test
 
 
             # bluegreen operator
@@ -252,7 +267,7 @@ class RunDbtDag:
                     dag=self.dag
                 )
 
-                dbt_build_artifact_tables >> dbt_seed
+                dbt_build_artifact_tables >> dbt_deps
 
             # Trigger downstream DAG when `dbt run` succeeds
             if self.external_dags:

--- a/ea_airflow_util/dags/run_dbt_airflow_dag.py
+++ b/ea_airflow_util/dags/run_dbt_airflow_dag.py
@@ -11,11 +11,11 @@ from airflow.operators.python import PythonOperator
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.utils.task_group import TaskGroup
 
-from airflow_dbt.operators.dbt_operator import DbtRunOperator, DbtSeedOperator, DbtTestOperator, DbtDepsOperator
+from airflow_dbt.operators.dbt_operator import DbtRunOperator, DbtSeedOperator, DbtTestOperator
 
 from ea_airflow_util.dags.ea_custom_dag import EACustomDAG
 from ea_airflow_util.callables.variable import check_variable, update_variable
-from ea_airflow_util.providers.dbt.operators.dbt import DbtRunOperationOperator
+from ea_airflow_util.providers.dbt.operators.dbt import DbtRunOperationOperator, DbtDepsUpgradeOperator
 
 
 class RunDbtDag:
@@ -56,6 +56,8 @@ class RunDbtDag:
         run_vars: Optional[dict] = None,
         test_vars: Optional[dict] = None,
 
+        deps_upgrade: bool = True,
+
         opt_swap: bool = False,
         opt_dest_schema: Optional[str] = None,
         opt_swap_target: Optional[str] = None,
@@ -82,6 +84,9 @@ class RunDbtDag:
         self.seed_vars = seed_vars
         self.run_vars = run_vars
         self.test_vars = run_vars
+
+        # whether to attach --upgrade when running dbt deps
+        self.deps_upgrade = deps_upgrade
 
         # bluegreen
         self.opt_swap        = opt_swap
@@ -171,7 +176,7 @@ class RunDbtDag:
             dag=self.dag
         ) as dbt_task_group:
 
-            dbt_deps = DbtDepsOperator(
+            dbt_deps = DbtDepsUpgradeOperator(
                 task_id= f'dbt_deps_{self.environment}',
                 dir    = self.dbt_repo_path,
                 target = self.dbt_target_name,
@@ -179,6 +184,7 @@ class RunDbtDag:
                 trigger_rule='all_success',
                 full_refresh=True,
                 vars=self.deps_vars,
+                upgrade=self.deps_upgrade,
                 dag=self.dag
 
             )

--- a/ea_airflow_util/providers/dbt/operators/dbt.py
+++ b/ea_airflow_util/providers/dbt/operators/dbt.py
@@ -7,7 +7,7 @@ import json
 
 from typing import Optional
 
-from airflow_dbt.operators.dbt_operator import DbtBaseOperator
+from airflow_dbt.operators.dbt_operator import DbtBaseOperator, DbtDepsOperator
 
 
 class DbtRunOperationOperator(DbtBaseOperator):
@@ -29,3 +29,17 @@ class DbtRunOperationOperator(DbtBaseOperator):
             cmd_pieces.extend(["--args", f'{json.dumps(self.arguments)}'])
 
         self.create_hook().run_cli(*cmd_pieces)
+
+class DbtDepsUpgradeOperator(DbtDepsOperator):
+    """
+    Without forking the hook code, we don't have a way to pass the --upgrade flag to deps.
+    """
+    def __init__(self, upgrade=False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.upgrade = upgrade
+    
+    def execute(self, context):
+        if self.upgrade:
+            self.create_hook().run_cli('deps', '--upgrade')
+        else:
+            self.create_hook().run_cli('deps')


### PR DESCRIPTION
This adds dbt deps as a **required** task to the front of the dbt run dag. This will alleviate inconsistent patch upgrades for stadium implementations, assuming they have correctly pinned version ranges in the `packages.yml`

By default, will run `dbt deps --upgrade` (necessary to actually upgrade to point releases), but can be configured otherwise by setting `deps_upgrade = False`. 

Otherwise, no configuration required.

Tested on boston & tx airflow dev. boston: 6 seconds runtime. TX: 23 seconds runtime.