### PR TITLE
Feature/airflow 2.11

### DIFF
--- a/ea_airflow_util/dags/s3_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/s3_to_snowflake_dag.py
@@ -1,6 +1,6 @@
 import os
 
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
 from airflow.utils.helpers import chain
 

--- a/ea_airflow_util/dags/sftp_to_snowflake_dag.py
+++ b/ea_airflow_util/dags/sftp_to_snowflake_dag.py
@@ -6,8 +6,8 @@ from typing import Optional
 
 from airflow.exceptions import AirflowSkipException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.operators.bash_operator import BashOperator
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.utils.task_group import TaskGroup
 

--- a/ea_airflow_util/providers/aws/operators/s3.py
+++ b/ea_airflow_util/providers/aws/operators/s3.py
@@ -8,7 +8,6 @@ from airflow.exceptions import AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.operators.s3 import S3FileTransformOperator
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from airflow.utils.decorators import apply_defaults
 
 
 class LoopS3FileTransformOperator(S3FileTransformOperator):
@@ -105,7 +104,6 @@ class S3ToSnowflakeOperator(BaseOperator):
     """
     template_fields = ('s3_destination_key', 's3_destination_dir', 's3_destination_filename',)
 
-    @apply_defaults
     def __init__(self,
         *,
         snowflake_conn_id: str,


### PR DESCRIPTION
## Description & motivation
This PR upgrades ea_airflow_util to the latest standards of `Airflow 2.11.0`, the final 2.x release before 3.x. The main changes are:
- Import path updates ([AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21:+Changes+in+import+paths))
- Removal of the deprecated[ `@apply_defaults` decorator](https://airflow.apache.org/docs/apache-airflow-providers-http/2.1.2/index.html#breaking-changes) parameter.

## PR Merge Priority:
- [x] Low
- [ ] Medium
- [ ] High

## Changes to existing files:

**Deprecated import path updates ([AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21:+Changes+in+import+paths)):**
These `_operator`/`_hook` suffixed modules were deprecated in Airflow 2.0. The updated paths have been available since 2.0 and are compatible with 2.11 and 3.x.
- `ea_airflow_util/dags/s3_to_snowflake_dag.py`:
  - `airflow.operators.python_operator` --> `airflow.operators.pythor`
- `ea_airflow_util/dags/sftp_to_snowflake_dag.py`:
  - `airflow.operators.bash_operator` --> `airflow.operators.bash`
  - `airflow.operators.python_operator` --> `airflow.operators.python`

**`@apply_defaults` decorator removal:**
- `ea_airflow_util/providers/aws/operators/s3.py`:
  - Removed `@apply_defaults` decorator and its import. This decorator has been a [no-op since Airflow 2.1](https://airflow.apache.org/docs/apache-airflow-providers-http/2.1.2/index.html#breaking-changes), it is now automatically applied via the `BaseOperator` class. Removing it eliminates deprecation warnings and prevents breakage when we migrate fully to 3.x in the future.