### PR TITLE
STADIUM-99: Convert airflow interactions with snowflake to use key-pair auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# ea_airflow_util v0.3.x
+
+## New features
+- Add `snowflake_keypair` callable for generating Snowflake RSA keypairs and rotating Snowflake user public keys.
+- Add `SnowflakeKeypairRotationDag` for automating Snowflake keypair rotation.
+
+## Under the hood
+- Implement OpenSSL based key generation for Snowflake keypair authentication.
+- Rotate Snowflake user public keys using the slots `RSA_PUBLIC_KEY` and `RSA_PUBLIC_KEY_2` .
+
 # ea_airflow_util v0.3.7
 ## Fixes
 - Fix change in interface in `SlackWebhookHook` instantiation in Slack callables.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,51 @@ This will be investigated further and patched in a future update.
 
 </details>
 
+## snowflake_keypair
+Helpers for generating Snowflake key-pair files and rotating Snowflake user public keys
+
+<details>
+<summary>See more:</summary>
+
+-----
+
+### generate_keypair_with_openssl(output_dir, snowflake_user)
+Generate a Snowflake RSA keypair on disk.
+
+Creates:
+
+- `<output_dir>/<snowflake_user>.p8`
+- `<output_dir>/<snowflake_user>.pub`
+
+Returns the private key, public key, and formatted public key body for Snowflake.
+
+### pick_rotation_slots(desc_user_rows)
+Determine which Snowflake public key slot should be used for rotation.
+
+Returns the new slot to write to and the old slot to unset.
+Raises an error if both key slots are already populated.
+
+### set_user_public_key(hook, snowflake_user, new_slot, public_key_body, **kwargs)
+Set the new public key in the selected Snowflake key slot.
+
+### unset_public_key_slot(hook, snowflake_user, slot, **kwargs)
+Unset a specific public key slot on a Snowflake user.
+
+### rotate_keypair(key_rotator_conn_id, snowflake_user, output_dir, **kwargs)
+Rotate a Snowflake user's keypair.
+
+Generates a new keypair, sets the new public key in Snowflake, and unsets the old key slot.
+If rotation fails after the new key is set, cleanup is attempted so the user is not left with both key slots populated.
+
+### initial_keypair(snowflake_user, output_dir, **kwargs)
+Generate an initial keypair for a Snowflake user when no keys exist yet.
+
+Returns the generated key file paths and the `ALTER USER` SQL needed to manually set the initial public key.
+
+-----
+
+</details>
+
 
 ## snowflake
 Helpers for getting data out of and into Snowflake
@@ -623,7 +668,26 @@ For example, `/ed-fi/apiClients/districts-2425-ds5/{tenant_code}/prod/Stadium` w
 
 </details>
 
+## SnowflakeKeypairRotationDag
+This dag is for rotating Snowflake key-pairs for one or more Snowflake users.
 
+A separate task is created for each user in `snowflake_users`.
+Each task calls `snowflake_keypair.rotate_keypair`, which generates a new keypair, sets the new public key in Snowflake, and unsets the old key slot.
+
+<details>
+<summary>Arguments:</summary>
+
+-----
+
+| Argument            | Description                                                                 |
+|---------------------|-----------------------------------------------------------------------------|
+| key_rotator_conn_id | Snowflake Airflow connection ID used to run `DESC USER` and `ALTER USER`    |
+| snowflake_users     | list of Snowflake users whose keypairs should be rotated                    |
+| key_dir             | directory where `.p8` and `.pub` key files are written (default `/efs/snowflake_keys`) |
+
+-----
+
+</details>
 
 # Providers
 Finally, this package contains a handful of custom DBT operators to be used as an alternative to PythonOperators.

--- a/ea_airflow_util/__init__.py
+++ b/ea_airflow_util/__init__.py
@@ -8,6 +8,8 @@ from ea_airflow_util.dags.s3_to_snowflake_dag import S3ToSnowflakeDag
 from ea_airflow_util.dags.dbt_snapshot_dag import DbtSnapshotDag
 from ea_airflow_util.dags.sftp_to_snowflake_dag import SFTPToSnowflakeDag
 from ea_airflow_util.dags.sharefile_custom_users_dag import LoadSharefileCustomUsersDag
+from ea_airflow_util.dags.snowflake_keypair_dag import SnowflakeKeypairRotationDag
+
 
 from ea_airflow_util.callables.airflow import xcom_pull_template
 from ea_airflow_util.callables import slack as slack_callbacks

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -183,9 +183,10 @@ def rotate_keypair(
 
         return result
 
-    # If something fails after setting the new key but before the old one is unset,
-    # the user could end up with both key slots filled. Try to clean up by removing
-    # the newly added key so the next rotation can run normally.
+    # If something fails after setting the new key but before unsetting the old slot,
+    # both key slots can end up filled, which blocks future rotations (e.g. if the DAG
+    # or server fails mid run). To recover, we unset the old slot so retries can proceed
+    # using the newly set key and free up a slot.
     except Exception:
         if new_key_set and old_slot:
             logging.exception(f"Rotation failed after setting new slot `{new_slot}` for `{snowflake_user}`. Attempting cleanup.")

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -62,15 +62,19 @@ def pick_rotation_slots(desc_user_rows: list[tuple]) -> Tuple[str, Optional[str]
     key_1 = user_att.get("RSA_PUBLIC_KEY")
     key_2 = user_att.get("RSA_PUBLIC_KEY_2")
 
-    if key_1 and key_2:
+    # If both key slots are set, rotation is not allowed
+    if key_1 not in (None, "", "null") and key_2 not in (None, "", "null"): #TODO: is there a better way to do this?
         raise RuntimeError("Both RSA_PUBLIC_KEY and RSA_PUBLIC_KEY_2 are set; refusing rotation.")
 
-    if (not key_1) and (not key_2):
+    # If neither key slot is set, use RSA_PUBLIC_KEY for initial set
+    if key_1 in (None, "", "null") and key_2 in (None, "", "null"):
         return "RSA_PUBLIC_KEY", None
 
-    if key_1 and (not key_2):
+    # If only RSA_PUBLIC_KEY is set, rotate to RSA_PUBLIC_KEY_2
+    if key_1 not in (None, "", "null"):
         return "RSA_PUBLIC_KEY_2", "RSA_PUBLIC_KEY"
 
+    # If only RSA_PUBLIC_KEY_2 is set, rotate to RSA_PUBLIC_KEY
     return "RSA_PUBLIC_KEY", "RSA_PUBLIC_KEY_2"
 
 
@@ -82,12 +86,15 @@ def set_user_public_key(
 ) -> Dict[str, str]:
     """
     Set the next available public key on a Snowflake user.
+
+    https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation
     """
     hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id)
 
     desc = hook.get_records(f"DESC USER {snowflake_user}")
     new_slot, old_slot = pick_rotation_slots(desc)
 
+    # Set the new public key in the slot
     hook.run(f"ALTER USER {snowflake_user} SET {new_slot}='{public_key_body}'")
 
     logging.info(f"Set `{new_slot}` for Snowflake user `{snowflake_user}`.")

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -20,6 +20,7 @@ def generate_keypair_with_openssl(
     private_path = os.path.join(output_dir, f"{key_name}.p8")
     public_path  = os.path.join(output_dir, f"{key_name}.pub")
 
+    # https://docs.snowflake.com/en/user-guide/key-pair-auth
     subprocess.run(
         f"openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out {private_path} -nocrypt",
         shell=True,
@@ -74,7 +75,7 @@ def pick_rotation_slots(desc_user_rows: list[tuple]) -> Tuple[str, Optional[str]
 
 
 def set_user_public_key(
-    admin_conn_id: str,
+    key_rotator_conn_id: str,
     snowflake_user: str,
     public_key_body: str,
     **kwargs 
@@ -82,7 +83,7 @@ def set_user_public_key(
     """
     Set the next available public key on a Snowflake user.
     """
-    hook = SnowflakeHook(snowflake_conn_id=admin_conn_id)
+    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id)
 
     desc = hook.get_records(f"DESC USER {snowflake_user}")
     new_slot, old_slot = pick_rotation_slots(desc)
@@ -98,7 +99,7 @@ def set_user_public_key(
 
 
 def unset_old_public_key(
-    admin_conn_id: str,
+    key_rotator_conn_id: str,
     snowflake_user: str,
     old_slot: Optional[str],
     **kwargs 
@@ -110,7 +111,7 @@ def unset_old_public_key(
         logging.info(f"No old key slot to unset for `{snowflake_user}`.")
         return
 
-    hook = SnowflakeHook(snowflake_conn_id=admin_conn_id)
+    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id)
     hook.run(f"ALTER USER {snowflake_user} UNSET {old_slot}")
 
     logging.info(f"Unset `{old_slot}` for Snowflake user `{snowflake_user}`.")
@@ -134,7 +135,7 @@ def test_current_user(
 
 
 def rotate_keypair(
-    admin_conn_id: str,
+    key_rotator_conn_id: str,
     snowflake_user: str,
     key_name: str,
     output_dir: str,
@@ -158,7 +159,7 @@ def rotate_keypair(
     )
 
     slots = set_user_public_key(
-        admin_conn_id=admin_conn_id,
+        key_rotator_conn_id=key_rotator_conn_id,
         snowflake_user=snowflake_user,
         public_key_body=public_body,
     )
@@ -170,7 +171,7 @@ def rotate_keypair(
         )
 
     unset_old_public_key(
-        admin_conn_id=admin_conn_id,
+        key_rotator_conn_id=key_rotator_conn_id,
         snowflake_user=snowflake_user,
         old_slot=slots.get("old_slot") or None,
     )

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -124,29 +124,10 @@ def unset_old_public_key(
     logging.info(f"Unset `{old_slot}` for Snowflake user `{snowflake_user}`.")
 
 
-def test_current_user(
-    conn_id: str,
-    expected_user: str,
-    **kwargs 
-) -> None:
-    """
-    Test that a Snowflake connection authenticates as the expected user.
-    """
-    hook = SnowflakeHook(snowflake_conn_id=conn_id)
-    actual_user = hook.get_first("SELECT CURRENT_USER()")[0]
-
-    if actual_user.upper() != expected_user.upper():
-        raise RuntimeError(f"Test failed: expected `{expected_user}`, got `{actual_user}`.")
-
-    logging.info(f"Connection `{conn_id}` authenticated successfully as `{actual_user}`.")
-
-
 def rotate_keypair(
     key_rotator_conn_id: str,
     snowflake_user: str,
     output_dir: str,
-    test_conn_id: Optional[str] = None,
-    do_test: bool = True,
     **kwargs 
 ) -> Dict[str, str]:
     """
@@ -169,12 +150,6 @@ def rotate_keypair(
         snowflake_user=snowflake_user,
         public_key_body=public_body,
     )
-
-    if do_test and test_conn_id:
-        test_current_user(
-            conn_id=test_conn_id,
-            expected_user=snowflake_user,
-        )
 
     unset_old_public_key(
         key_rotator_conn_id=key_rotator_conn_id,

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -79,65 +79,61 @@ def pick_rotation_slots(desc_user_rows: list[tuple]) -> Tuple[str, Optional[str]
 
 
 def set_user_public_key(
-    key_rotator_conn_id: str,
+    hook: SnowflakeHook,
     snowflake_user: str,
+    new_slot: str,
     public_key_body: str,
-    **kwargs 
-) -> Dict[str, str]:
+    **kwargs
+) -> None:
     """
-    Set the next available public key on a Snowflake user.
+    Set the new public key in the selected slot.
 
     https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation
     """
-    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id, log_sql=False)
-
-    desc = hook.get_records(f"DESC USER {snowflake_user}")
-    new_slot, old_slot = pick_rotation_slots(desc)
-
-    # Set the new public key in the slot
     hook.run(f"ALTER USER {snowflake_user} SET {new_slot}='{public_key_body}'")
 
     logging.info(f"Set `{new_slot}` for Snowflake user `{snowflake_user}`.")
 
-    return {
-        "new_slot": new_slot,
-        "old_slot": old_slot or "",
-    }
 
-
-def unset_old_public_key(
-    key_rotator_conn_id: str,
+def unset_public_key_slot(
+    hook: SnowflakeHook,
     snowflake_user: str,
-    old_slot: Optional[str],
-    **kwargs 
+    slot: Optional[str],
+    **kwargs
 ) -> None:
     """
-    Unset the old public key slot after a successful rotation.
+    Unset a specific public key slot on a Snowflake user.
     """
-    if not old_slot:
+    if not slot:
         logging.info(f"No old key slot to unset for `{snowflake_user}`.")
         return
 
-    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id)
-    hook.run(f"ALTER USER {snowflake_user} UNSET {old_slot}")
+    hook.run(f"ALTER USER {snowflake_user} UNSET {slot}")
 
-    logging.info(f"Unset `{old_slot}` for Snowflake user `{snowflake_user}`.")
+    logging.info(f"Unset `{slot}` for Snowflake user `{snowflake_user}`.")
 
 
 def rotate_keypair(
     key_rotator_conn_id: str,
     snowflake_user: str,
     output_dir: str,
-    **kwargs 
+    **kwargs
 ) -> Dict[str, str]:
     """
     Rotate a Snowflake user's keypair.
 
     - generate new key files on disk
     - set the new public key in Snowflake
-    - test the updated connection if configured
     - unset the old key slot
+
+    Failure guardrail:
+    - if something fails after setting the new slot but before unsetting the old one,
+    attempt to unset the old slot so Snowflake still matches the new key written in /efs
     """
+    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id, log_sql=False) #turn off sql log
+
+    private_key_path = os.path.join(output_dir, f"{snowflake_user}.p8")
+    public_key_path = os.path.join(output_dir, f"{snowflake_user}.pub")
 
     # pull public key from generated keypair
     _, _, public_body = generate_keypair_with_openssl(
@@ -145,35 +141,78 @@ def rotate_keypair(
         snowflake_user=snowflake_user,
     )
 
-    slots = set_user_public_key(
-        key_rotator_conn_id=key_rotator_conn_id,
-        snowflake_user=snowflake_user,
-        public_key_body=public_body,
-    )
+    new_slot = None
+    old_slot = None
+    new_key_set = False
 
-    unset_old_public_key(
-        key_rotator_conn_id=key_rotator_conn_id,
-        snowflake_user=snowflake_user,
-        old_slot=slots.get("old_slot") or None,
-    )
+    try:
+        desc = hook.get_records(f"DESC USER {snowflake_user}")
+        new_slot, old_slot = pick_rotation_slots(desc)
 
-    return {
-        "snowflake_user": snowflake_user,
-        "new_slot": slots.get("new_slot", ""),
-        "old_slot_unset": slots.get("old_slot", ""),
-        "key_file_path": os.path.join(output_dir, f"{snowflake_user}.p8"),
-        "public_key_path": os.path.join(output_dir, f"{snowflake_user}.pub"),
-    }
+        logging.info(f"Rotation for `{snowflake_user}`: new_slot=`{new_slot}`, old_slot=`{old_slot or 'none'}`.")
 
+        set_user_public_key(
+            hook=hook,
+            snowflake_user=snowflake_user,
+            new_slot=new_slot,
+            public_key_body=public_body,
+        )
+        new_key_set = True # new key was set
 
+        # unset the old slot
+        unset_public_key_slot(
+            hook=hook,
+            snowflake_user=snowflake_user,
+            slot=old_slot,
+        )
+
+        result = {
+            "snowflake_user": snowflake_user,
+            "new_slot": new_slot or "",
+            "old_slot_unset": old_slot or "",
+            "key_file_path": private_key_path,
+            "public_key_path": public_key_path,
+        }
+
+        logging.info(
+            f"Successfully rotated keypair for `{result['snowflake_user']}`: new_slot=`{result['new_slot']}`,"
+            f" old_slot_unset=`{result['old_slot_unset'] or 'none'}`,"
+            f" private_key=`{result['key_file_path']}`,"
+            f" public_key=`{result['public_key_path']}`."
+        )
+
+        return result
+
+    # If something fails after setting the new key but before the old one is unset,
+    # the user could end up with both key slots filled. Try to clean up by removing
+    # the newly added key so the next rotation can run normally.
+    except Exception:
+        if new_key_set and old_slot:
+            logging.exception(f"Rotation failed after setting new slot `{new_slot}` for `{snowflake_user}`. Attempting cleanup.")
+            try:
+                unset_public_key_slot(
+                    hook=hook,
+                    snowflake_user=snowflake_user,
+                    slot=old_slot,
+                )
+                logging.info(f"Cleanup succeeded for `{snowflake_user}`: unset old slot `{old_slot}`.")
+            except Exception:
+                logging.exception(f"Cleanup  failed for `{snowflake_user}`: unable to unset old slot `{old_slot}`.")
+
+        raise
+
+# function to use on initial keypair generation when no keys exist yet (e.g. to make key for key rotator)
 def initial_keypair(
     snowflake_user: str,
     output_dir: str,
-    **kwargs 
+    **kwargs
 ) -> Dict[str, str]:
     """
     Generate the initial keypair for a Snowflake user.
     """
+    private_key_path = os.path.join(output_dir, f"{snowflake_user}.p8")
+    public_key_path = os.path.join(output_dir, f"{snowflake_user}.pub")
+
     _, _, public_body = generate_keypair_with_openssl(
         output_dir=output_dir,
         snowflake_user=snowflake_user,
@@ -184,6 +223,6 @@ def initial_keypair(
     return {
         "snowflake_user": snowflake_user,
         "alter_user_sql": f"ALTER USER {snowflake_user} SET RSA_PUBLIC_KEY='{public_body}';",
-        "key_file_path": os.path.join(output_dir, f"{snowflake_user}.p8"),
-        "public_key_path": os.path.join(output_dir, f"{snowflake_user}.pub"),
+        "key_file_path": private_key_path,
+        "public_key_path": public_key_path,
     }

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -1,0 +1,211 @@
+import logging
+import os
+import subprocess
+
+from typing import Optional, Tuple, Dict
+
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+
+
+def generate_keypair_with_openssl(
+    output_dir: str,
+    key_name: str,
+    **kwargs
+) -> Tuple[str, str, str]:
+    """
+    Generate a Snowflake RSA keypair using openssl.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    private_path = os.path.join(output_dir, f"{key_name}.p8")
+    public_path  = os.path.join(output_dir, f"{key_name}.pub")
+
+    subprocess.run(
+        f"openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out {private_path} -nocrypt",
+        shell=True,
+        check=True,
+        executable="/bin/bash",
+    )
+
+    subprocess.run(
+        f"openssl rsa -in {private_path} -pubout -out {public_path}",
+        shell=True,
+        check=True,
+        executable="/bin/bash",
+    )
+
+    with open(private_path, "r", encoding="utf-8") as reader:
+        private_pem = reader.read()
+
+    with open(public_path, "r", encoding="utf-8") as reader:
+        public_pem = reader.read()
+
+    public_body = (
+        public_pem.replace("-----BEGIN PUBLIC KEY-----", "")
+        .replace("-----END PUBLIC KEY-----", "")
+        .replace("\n", "")
+        .replace("\r", "")
+        .strip()
+    )
+
+    logging.info(f"Generated keypair for `{key_name}` in `{output_dir}`.")
+
+    return private_pem, public_pem, public_body
+
+
+def pick_rotation_slots(desc_user_rows: list[tuple]) -> Tuple[str, Optional[str]]:
+    """
+    Determine which Snowflake public key slot to use for rotation.
+    """
+    user_att  = {row[0]: row[1] for row in desc_user_rows}
+    key_1 = user_att.get("RSA_PUBLIC_KEY")
+    key_2 = user_att.get("RSA_PUBLIC_KEY_2")
+
+    if key_1 and key_2:
+        raise RuntimeError("Both RSA_PUBLIC_KEY and RSA_PUBLIC_KEY_2 are set; refusing rotation.")
+
+    if (not key_1) and (not key_2):
+        return "RSA_PUBLIC_KEY", None
+
+    if key_1 and (not key_2):
+        return "RSA_PUBLIC_KEY_2", "RSA_PUBLIC_KEY"
+
+    return "RSA_PUBLIC_KEY", "RSA_PUBLIC_KEY_2"
+
+
+def set_user_public_key(
+    admin_conn_id: str,
+    snowflake_user: str,
+    public_key_body: str,
+    **kwargs 
+) -> Dict[str, str]:
+    """
+    Set the next available public key on a Snowflake user.
+    """
+    hook = SnowflakeHook(snowflake_conn_id=admin_conn_id)
+
+    desc = hook.get_records(f"DESC USER {snowflake_user}")
+    new_slot, old_slot = pick_rotation_slots(desc)
+
+    hook.run(f"ALTER USER {snowflake_user} SET {new_slot}='{public_key_body}'")
+
+    logging.info(f"Set `{new_slot}` for Snowflake user `{snowflake_user}`.")
+
+    return {
+        "new_slot": new_slot,
+        "old_slot": old_slot or "",
+    }
+
+
+def unset_old_public_key(
+    admin_conn_id: str,
+    snowflake_user: str,
+    old_slot: Optional[str],
+    **kwargs 
+) -> None:
+    """
+    Unset the old public key slot after a successful rotation.
+    """
+    if not old_slot:
+        logging.info(f"No old key slot to unset for `{snowflake_user}`.")
+        return
+
+    hook = SnowflakeHook(snowflake_conn_id=admin_conn_id)
+    hook.run(f"ALTER USER {snowflake_user} UNSET {old_slot}")
+
+    logging.info(f"Unset `{old_slot}` for Snowflake user `{snowflake_user}`.")
+
+
+def test_current_user(
+    conn_id: str,
+    expected_user: str,
+    **kwargs 
+) -> None:
+    """
+    Test that a Snowflake connection authenticates as the expected user.
+    """
+    hook = SnowflakeHook(snowflake_conn_id=conn_id)
+    actual_user = hook.get_first("SELECT CURRENT_USER()")[0]
+
+    if actual_user.upper() != expected_user.upper():
+        raise RuntimeError(f"Test failed: expected `{expected_user}`, got `{actual_user}`.")
+
+    logging.info(f"Connection `{conn_id}` authenticated successfully as `{actual_user}`.")
+
+
+def rotate_keypair(
+    admin_conn_id: str,
+    snowflake_user: str,
+    key_name: str,
+    output_dir: str,
+    test_conn_id: Optional[str] = None,
+    do_test: bool = True,
+    **kwargs 
+) -> Dict[str, str]:
+    """
+    Rotate a Snowflake user's keypair.
+
+    - generate new key files on disk
+    - set the new public key in Snowflake
+    - test the updated connection if configured
+    - unset the old key slot
+    """
+
+    # pull public key from generated keypair
+    _, _, public_body = generate_keypair_with_openssl(
+        output_dir=output_dir,
+        key_name=key_name,
+    )
+
+    slots = set_user_public_key(
+        admin_conn_id=admin_conn_id,
+        snowflake_user=snowflake_user,
+        public_key_body=public_body,
+    )
+
+    if do_test and test_conn_id:
+        test_current_user(
+            conn_id=test_conn_id,
+            expected_user=snowflake_user,
+        )
+
+    unset_old_public_key(
+        admin_conn_id=admin_conn_id,
+        snowflake_user=snowflake_user,
+        old_slot=slots.get("old_slot") or None,
+    )
+
+    return {
+        "snowflake_user": snowflake_user,
+        "new_slot": slots.get("new_slot", ""),
+        "old_slot_unset": slots.get("old_slot", ""),
+        "key_file_path": os.path.join(output_dir, f"{key_name}.p8"),
+        "public_key_path": os.path.join(output_dir, f"{key_name}.pub"),
+    }
+
+
+def initial_keypair(
+    key_name: str,
+    snowflake_user: str,
+    output_dir: str,
+    **kwargs 
+) -> Dict[str, str]:
+    """
+    Generate the initial keypair for a Snowflake user.
+
+    This helper will generates the key files
+    and returns the ALTER USER statement to run manually in Snowflake.
+    """
+    _, _, public_body = generate_keypair_with_openssl(
+        output_dir=output_dir,
+        key_name=key_name,
+    )
+
+    logging.info(f"Generated initial keypair for Snowflake user `{snowflake_user}`.")
+
+    return {
+        "snowflake_user": snowflake_user,
+        "alter_user_sql": f"ALTER USER {snowflake_user} SET RSA_PUBLIC_KEY='{public_body}';",
+        "key_file_path": os.path.join(output_dir, f"{key_name}.p8"),
+        "public_key_path": os.path.join(output_dir, f"{key_name}.pub"),
+    }

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -89,7 +89,7 @@ def set_user_public_key(
 
     https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation
     """
-    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id)
+    hook = SnowflakeHook(snowflake_conn_id=key_rotator_conn_id, log_sql=False)
 
     desc = hook.get_records(f"DESC USER {snowflake_user}")
     new_slot, old_slot = pick_rotation_slots(desc)

--- a/ea_airflow_util/callables/snowflake_keypair.py
+++ b/ea_airflow_util/callables/snowflake_keypair.py
@@ -9,7 +9,7 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 
 def generate_keypair_with_openssl(
     output_dir: str,
-    key_name: str,
+    snowflake_user: str,
     **kwargs
 ) -> Tuple[str, str, str]:
     """
@@ -17,8 +17,8 @@ def generate_keypair_with_openssl(
     """
     os.makedirs(output_dir, exist_ok=True)
 
-    private_path = os.path.join(output_dir, f"{key_name}.p8")
-    public_path  = os.path.join(output_dir, f"{key_name}.pub")
+    private_path = os.path.join(output_dir, f"{snowflake_user}.p8")
+    public_path  = os.path.join(output_dir, f"{snowflake_user}.pub")
 
     # https://docs.snowflake.com/en/user-guide/key-pair-auth
     subprocess.run(
@@ -49,7 +49,7 @@ def generate_keypair_with_openssl(
         .strip()
     )
 
-    logging.info(f"Generated keypair for `{key_name}` in `{output_dir}`.")
+    logging.info(f"Generated keypair for `{snowflake_user}` in `{output_dir}`.")
 
     return private_pem, public_pem, public_body
 
@@ -137,7 +137,6 @@ def test_current_user(
 def rotate_keypair(
     key_rotator_conn_id: str,
     snowflake_user: str,
-    key_name: str,
     output_dir: str,
     test_conn_id: Optional[str] = None,
     do_test: bool = True,
@@ -155,7 +154,7 @@ def rotate_keypair(
     # pull public key from generated keypair
     _, _, public_body = generate_keypair_with_openssl(
         output_dir=output_dir,
-        key_name=key_name,
+        snowflake_user=snowflake_user,
     )
 
     slots = set_user_public_key(
@@ -180,26 +179,22 @@ def rotate_keypair(
         "snowflake_user": snowflake_user,
         "new_slot": slots.get("new_slot", ""),
         "old_slot_unset": slots.get("old_slot", ""),
-        "key_file_path": os.path.join(output_dir, f"{key_name}.p8"),
-        "public_key_path": os.path.join(output_dir, f"{key_name}.pub"),
+        "key_file_path": os.path.join(output_dir, f"{snowflake_user}.p8"),
+        "public_key_path": os.path.join(output_dir, f"{snowflake_user}.pub"),
     }
 
 
 def initial_keypair(
-    key_name: str,
     snowflake_user: str,
     output_dir: str,
     **kwargs 
 ) -> Dict[str, str]:
     """
     Generate the initial keypair for a Snowflake user.
-
-    This helper will generates the key files
-    and returns the ALTER USER statement to run manually in Snowflake.
     """
     _, _, public_body = generate_keypair_with_openssl(
         output_dir=output_dir,
-        key_name=key_name,
+        snowflake_user=snowflake_user,
     )
 
     logging.info(f"Generated initial keypair for Snowflake user `{snowflake_user}`.")
@@ -207,6 +202,6 @@ def initial_keypair(
     return {
         "snowflake_user": snowflake_user,
         "alter_user_sql": f"ALTER USER {snowflake_user} SET RSA_PUBLIC_KEY='{public_body}';",
-        "key_file_path": os.path.join(output_dir, f"{key_name}.p8"),
-        "public_key_path": os.path.join(output_dir, f"{key_name}.pub"),
+        "key_file_path": os.path.join(output_dir, f"{snowflake_user}.p8"),
+        "public_key_path": os.path.join(output_dir, f"{snowflake_user}.pub"),
     }

--- a/ea_airflow_util/dags/snowflake_keypair_dag.py
+++ b/ea_airflow_util/dags/snowflake_keypair_dag.py
@@ -10,11 +10,10 @@ from ea_airflow_util.callables import snowflake_keypair
 
 class SnowflakeKeypairRotationDag:
     """
-    
     """
     def __init__(self,
         *,
-        admin_conn_id: str,
+        key_rotator_conn_id: str,
 
         key_names: List[str],  # e.g. ["key_rotator", "loader","transformer"]
         snowflake_users: Dict[str, str],  # e.g. {"loader": "loader_prod", ...}
@@ -24,7 +23,7 @@ class SnowflakeKeypairRotationDag:
         do_test: bool = True,
         **kwargs
     ) -> None:
-        self.admin_conn_id = admin_conn_id
+        self.key_rotator_conn_id = key_rotator_conn_id
 
         self.key_names = key_names
         self.snowflake_users = snowflake_users
@@ -49,7 +48,7 @@ class SnowflakeKeypairRotationDag:
                     task_id="rotate_keypair_" + key_name,
                     python_callable=snowflake_keypair.rotate_keypair,
                     op_kwargs={
-                        "admin_conn_id": self.admin_conn_id,
+                        "key_rotator_conn_id": self.key_rotator_conn_id,
                         "snowflake_user": snowflake_user,
                         "key_name": key_name,
                         "output_dir": self.key_dir,

--- a/ea_airflow_util/dags/snowflake_keypair_dag.py
+++ b/ea_airflow_util/dags/snowflake_keypair_dag.py
@@ -14,16 +14,12 @@ class SnowflakeKeypairRotationDag:
         *,
         key_rotator_conn_id: str,
         snowflake_users: List[str],
-        test_conn_id: Optional[str] = None,
         key_dir: str = "/efs/snowflake_keys",
-        do_test: bool = True,
         **kwargs
     ) -> None:
         self.key_rotator_conn_id = key_rotator_conn_id
         self.snowflake_users = snowflake_users
-        self.test_conn_id = test_conn_id
         self.key_dir = key_dir
-        self.do_test = do_test
 
         self.dag = EACustomDAG(**kwargs)
         self.build_snowflake_keypair_rotation_dag()
@@ -36,9 +32,7 @@ class SnowflakeKeypairRotationDag:
                 op_kwargs={
                     "key_rotator_conn_id": self.key_rotator_conn_id,
                     "snowflake_user": snowflake_user,
-                    "output_dir": self.key_dir,
-                    "test_conn_id": self.test_conn_id,
-                    "do_test": self.do_test and self.test_conn_id is not None,
+                    "output_dir": self.key_dir
                 },
                 dag=self.dag,
             )

--- a/ea_airflow_util/dags/snowflake_keypair_dag.py
+++ b/ea_airflow_util/dags/snowflake_keypair_dag.py
@@ -1,5 +1,3 @@
-# ea_airflow_util/dags/snowflake_keypair_rotation_dag.py
-
 from typing import List, Optional
 
 from airflow.operators.python import PythonOperator

--- a/ea_airflow_util/dags/snowflake_keypair_dag.py
+++ b/ea_airflow_util/dags/snowflake_keypair_dag.py
@@ -1,6 +1,6 @@
 # ea_airflow_util/dags/snowflake_keypair_rotation_dag.py
 
-from typing import List, Optional, Dict
+from typing import List, Optional
 
 from airflow.operators.python import PythonOperator
 
@@ -9,56 +9,38 @@ from ea_airflow_util.callables import snowflake_keypair
 
 
 class SnowflakeKeypairRotationDag:
-    """
-    """
-    def __init__(self,
+    def __init__(
+        self,
         *,
         key_rotator_conn_id: str,
-
-        key_names: List[str],  # e.g. ["key_rotator", "loader","transformer"]
-        snowflake_users: Dict[str, str],  # e.g. {"loader": "loader_prod", ...}
-        test_conn_ids: Optional[Dict[str, str]] = None,  # e.g. {"key_rotator": "snowflake_key_rotator", "loader": "snowflake"}
-
+        snowflake_users: List[str],
+        test_conn_id: Optional[str] = None,
         key_dir: str = "/efs/snowflake_keys",
         do_test: bool = True,
         **kwargs
     ) -> None:
         self.key_rotator_conn_id = key_rotator_conn_id
-
-        self.key_names = key_names
         self.snowflake_users = snowflake_users
-        self.test_conn_ids = test_conn_ids or {}
-
+        self.test_conn_id = test_conn_id
         self.key_dir = key_dir
         self.do_test = do_test
 
         self.dag = EACustomDAG(**kwargs)
         self.build_snowflake_keypair_rotation_dag()
 
-
-    def build_snowflake_keypair_rotation_dag(self, **kwargs):
-
-        rotate_tasks = []
-        for key_name in self.key_names:
-            snowflake_user = self.snowflake_users[key_name]
-            test_conn_id = self.test_conn_ids.get(key_name)
-
-            rotate_tasks.append(
-                PythonOperator(
-                    task_id="rotate_keypair_" + key_name,
-                    python_callable=snowflake_keypair.rotate_keypair,
-                    op_kwargs={
-                        "key_rotator_conn_id": self.key_rotator_conn_id,
-                        "snowflake_user": snowflake_user,
-                        "key_name": key_name,
-                        "output_dir": self.key_dir,
-                        "test_conn_id": test_conn_id,
-                        "do_test": self.do_test and test_conn_id is not None,
-                    },
-                    dag=self.dag
-                )
+    def build_snowflake_keypair_rotation_dag(self, **kwargs) -> None:
+        for snowflake_user in self.snowflake_users:
+            PythonOperator(
+                task_id=f"rotate_keypair_{snowflake_user}",
+                python_callable=snowflake_keypair.rotate_keypair,
+                op_kwargs={
+                    "key_rotator_conn_id": self.key_rotator_conn_id,
+                    "snowflake_user": snowflake_user,
+                    "output_dir": self.key_dir,
+                    "test_conn_id": self.test_conn_id,
+                    "do_test": self.do_test and self.test_conn_id is not None,
+                },
+                dag=self.dag,
             )
-
-        rotate_tasks
 
         return

--- a/ea_airflow_util/dags/snowflake_keypair_dag.py
+++ b/ea_airflow_util/dags/snowflake_keypair_dag.py
@@ -1,0 +1,65 @@
+# ea_airflow_util/dags/snowflake_keypair_rotation_dag.py
+
+from typing import List, Optional, Dict
+
+from airflow.operators.python import PythonOperator
+
+from ea_airflow_util.dags.ea_custom_dag import EACustomDAG
+from ea_airflow_util.callables import snowflake_keypair
+
+
+class SnowflakeKeypairRotationDag:
+    """
+    
+    """
+    def __init__(self,
+        *,
+        admin_conn_id: str,
+
+        key_names: List[str],  # e.g. ["key_rotator", "loader","transformer"]
+        snowflake_users: Dict[str, str],  # e.g. {"loader": "loader_prod", ...}
+        test_conn_ids: Optional[Dict[str, str]] = None,  # e.g. {"key_rotator": "snowflake_key_rotator", "loader": "snowflake"}
+
+        key_dir: str = "/efs/snowflake_keys",
+        do_test: bool = True,
+        **kwargs
+    ) -> None:
+        self.admin_conn_id = admin_conn_id
+
+        self.key_names = key_names
+        self.snowflake_users = snowflake_users
+        self.test_conn_ids = test_conn_ids or {}
+
+        self.key_dir = key_dir
+        self.do_test = do_test
+
+        self.dag = EACustomDAG(**kwargs)
+        self.build_snowflake_keypair_rotation_dag()
+
+
+    def build_snowflake_keypair_rotation_dag(self, **kwargs):
+
+        rotate_tasks = []
+        for key_name in self.key_names:
+            snowflake_user = self.snowflake_users[key_name]
+            test_conn_id = self.test_conn_ids.get(key_name)
+
+            rotate_tasks.append(
+                PythonOperator(
+                    task_id="rotate_keypair_" + key_name,
+                    python_callable=snowflake_keypair.rotate_keypair,
+                    op_kwargs={
+                        "admin_conn_id": self.admin_conn_id,
+                        "snowflake_user": snowflake_user,
+                        "key_name": key_name,
+                        "output_dir": self.key_dir,
+                        "test_conn_id": test_conn_id,
+                        "do_test": self.do_test and test_conn_id is not None,
+                    },
+                    dag=self.dag
+                )
+            )
+
+        rotate_tasks
+
+        return


### PR DESCRIPTION
## Description & motivation
This PR builds Snowflake keypair rotation in airflow (relevant snowflake doc: [Key-pair authentication and key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth))

**Relevant jira ticket:** [here](https://edanalytics.atlassian.net/browse/STADIUM-99?atlOrigin=eyJpIjoiZGVmYTk2ZGEzZGI5NDVkYjllZTZhNDM0MzljMGI4YmMiLCJwIjoiaiJ9)

**See initial set-up steps here:** https://edanalytics.slite.com/app/docs/g1l4siZeyUCFf4

Key functionality added:

1. `snowflake_keypair` callable for generating RSA keypairs and managing Snowflake key slots
2. `SnowflakeKeypairRotationDag` dag for rotating keys for one or more Snowflake users
3. Keypairs are written in efs (`/efs/snowflake_keys`) so they remain available across Airflow redeployments (see related thread [here](https://edanalytics.slack.com/archives/C048TEZ9ALF/p1772140539084299))

The rotation logic uses Snowflake’s dual slot `RSA_PUBLIC_KEY` and  `RSA_PUBLIC_KEY_2` to rotate keys so authentication doesn't break (see more details here: [Configuring key-pair rotation](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-rotation)

## PR Merge Priority:
- [ ] Low
- [ ] Medium
- [x] High

## Changes to existing files:
None.


## New files created:
- `snowflake_keypair.py`  
  Helpers for generating Snowflake RSA keypairs, determining which Snowflake key slot should be used during rotation, setting new public keys, and unsetting old keys. 

- `snowflake_keypair_rotation_dag.py`  
  Airflow DAG that creates rotation tasks for a list of Snowflake users (e.g. loader and transformer). Each task calls the `rotate_keypair` callable to generate new keys and update the Snowflake user key.

## Tests and QC done:
- tested in stadium-ca-dev (see testing branch [here](https://github.com/edanalytics/stadium_ca/compare/main...feature/key-pair-testing))