### PR TITLE
Fix: Allow `sql.s3_to_postgres()` to rely on an IAM role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+# Unreleased changes
+## Fixes
+- Allow `sql.s3_to_postgres()` to rely on an IAM role by omitting `aws_commons.create_aws_credentials()` when the S3 connection has no login or password.
+
 # ea_airflow_util v0.4.1
 ## Fixes
 - Explicitly pass `bucket_name` into all method calls to `S3Hook`.
-
 
 # ea_airflow_util v0.4.0
 ## New features

--- a/ea_airflow_util/callables/sql.py
+++ b/ea_airflow_util/callables/sql.py
@@ -96,13 +96,17 @@ def s3_to_postgres(
     elif truncate and delete_qry:
         raise ValueError('Only specify one of truncate, delete_qry')
 
+    aws_credentials = ''
+    if s3_creds.login or s3_creds.password:
+        aws_credentials = f""",
+        aws_commons.create_aws_credentials('{s3_creds.login}', '{s3_creds.password}', '')"""
+
     copy_qry = f"""
         select aws_s3.table_import_from_s3(
         '{dest_table}',
         '{column_customization}',
         '{options}',
-        aws_commons.create_s3_uri('{s3_bucket}', '{s3_key}', '{s3_region}'),
-        aws_commons.create_aws_credentials('{s3_creds.login}', '{s3_creds.password}', '')
+        aws_commons.create_s3_uri('{s3_bucket}', '{s3_key}', '{s3_region}'){aws_credentials}
         );
     """
 


### PR DESCRIPTION
We're aiming to move away from handling S3 credentials directly in Airflow connections. Removing them from the connection objects is one thing, but this SQL snippet also expects them to be present, causing errors when they are not defined:
```
Provide both an access key and a secret key or leave both parameters empty. If the parameters are empty, the credentials associated with the database instance are used.
```